### PR TITLE
fix: account for embedded newlines in prompt header line count

### DIFF
--- a/README/development.md
+++ b/README/development.md
@@ -18,7 +18,7 @@ Lint:
 
 Generate HTML API Documentation:
 
-`bunx typedoc --readme none index.ts`
+`bunx typedoc index.ts`
 
 ### Debug Logging
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
   },
   "typedocOptions": {
     "readme": "none",
-    "exclude": ["tests/**"]
+    "exclude": [
+      "tests/**"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,5 +39,9 @@
   },
   "peerDependencies": {
     "typescript": "^6.0.3"
+  },
+  "typedocOptions": {
+    "readme": "none",
+    "exclude": ["tests/**"]
   }
 }

--- a/src/cli/BaseCLI.ts
+++ b/src/cli/BaseCLI.ts
@@ -233,7 +233,7 @@ export default class BaseCLI implements CLI {
     let completionService: DefaultCompletionService | undefined;
     if (this.#options.completionServiceEnabled) {
       completionService = new DefaultCompletionService();
-      this.addServiceProvider(new CompletionServiceProvider(60, completionService));
+      this.addServiceProvider(new CompletionServiceProvider(5, completionService));
     }
 
     const configurationServiceProvider = new ConfigurationServiceProvider(

--- a/src/service/prompter/prompt/PromptContext.ts
+++ b/src/service/prompter/prompt/PromptContext.ts
@@ -14,8 +14,10 @@ export interface PromptContext {
 export function physicalLineCount(terminal: Terminal, text: string): number {
   const cols = terminal.columns();
   if (cols <= 0) return 1;
-  const width = Bun.stringWidth(text);
-  return Math.max(1, Math.ceil(width / cols));
+  return text.split("\n").reduce((sum, segment) => {
+    const width = Bun.stringWidth(segment);
+    return sum + Math.max(1, Math.ceil(width / cols));
+  }, 0);
 }
 
 export function headerLineCount(terminal: Terminal, promptDef: Prompt): number {

--- a/src/terminal/TtyKeyReader.ts
+++ b/src/terminal/TtyKeyReader.ts
@@ -27,6 +27,25 @@ export default class TtyKeyReader implements KeyReader {
     return new Promise((resolve) => {
       const onData = (data: Buffer): void => {
         this.#ttyReadStream.removeListener("data", onData);
+
+        // A lone 0x1b may be the start of a multi-byte escape sequence (e.g. arrow keys).
+        // Wait briefly for the rest of the sequence before decoding.
+        if (data.length === 1 && data[0] === 0x1b) {
+          const timeout = setTimeout(() => {
+            this.#ttyReadStream.removeListener("data", onMore);
+            resolve(TtyKeyReader.#decodeKeyEvent(data));
+          }, 20);
+
+          const onMore = (more: Buffer): void => {
+            clearTimeout(timeout);
+            this.#ttyReadStream.removeListener("data", onMore);
+            resolve(TtyKeyReader.#decodeKeyEvent(Buffer.concat([data, more])));
+          };
+
+          this.#ttyReadStream.once("data", onMore);
+          return;
+        }
+
         resolve(TtyKeyReader.#decodeKeyEvent(data));
       };
       this.#ttyReadStream.on("data", onData);

--- a/tests/service/prompter/prompt/PromptContext.test.ts
+++ b/tests/service/prompter/prompt/PromptContext.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { physicalLineCount } from "../../../../src/service/prompter/prompt/PromptContext.ts";
+import type Terminal from "../../../../src/terminal/Terminal.ts";
+
+class MockTerminal implements Terminal {
+  readonly #cols: number;
+  constructor(cols: number) {
+    this.#cols = cols;
+  }
+  columns(): number {
+    return this.#cols;
+  }
+  rows(): number {
+    return 24;
+  }
+  clearLine(): Promise<void> {
+    return Promise.resolve();
+  }
+  clearUpLines(): Promise<void> {
+    return Promise.resolve();
+  }
+  hideCursor(): Promise<void> {
+    return Promise.resolve();
+  }
+  showCursor(): Promise<void> {
+    return Promise.resolve();
+  }
+  write(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+describe("physicalLineCount", () => {
+  test("single short text fits on one line", () => {
+    expect(physicalLineCount(new MockTerminal(80), "hello")).toBe(1);
+  });
+
+  test("text wider than terminal wraps", () => {
+    // 11 chars on a 10-col terminal => 2 lines
+    expect(physicalLineCount(new MockTerminal(10), "hello world")).toBe(2);
+  });
+
+  test("embedded newline on wide terminal counts as two lines", () => {
+    // Both parts fit on one line (terminal 300 cols > 127 and > 81),
+    // but the embedded \n always forces 2 rendered lines
+    const text =
+      "This will set up your terminal so that pressing TAB while typing commands will show possible options and autocomplete arguments.\n(Enabling autocompletion will modify configuration files in your home directory.)";
+    expect(physicalLineCount(new MockTerminal(300), text)).toBe(2);
+  });
+
+  test("embedded newline combined with wrapping", () => {
+    // "hello world" (11 chars) => ceil(11/10) = 2 lines
+    // "foo" (3 chars) => ceil(3/10) = 1 line
+    // total = 3
+    expect(physicalLineCount(new MockTerminal(10), "hello world\nfoo")).toBe(3);
+  });
+
+  test("zero columns returns 1", () => {
+    expect(physicalLineCount(new MockTerminal(0), "hello")).toBe(1);
+  });
+});

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,4 +1,0 @@
-{
-  "extends": "../tsconfig.json",
-  "include": ["./**/*.ts"]
-}

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["./**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- `physicalLineCount` used `Bun.stringWidth(text)` on the full string, but `Bun.stringWidth("\n") === 0`, so any embedded newline was treated as zero-width. This caused the entire text to be measured as one wrapped block.
- When text containing `\n` is written to the terminal, each newline forces a hard line break regardless of terminal width, so the physical line count was undercounted.
- This caused `clearUpLines` to be called with too low a count, leaving stale header lines on screen when re-rendering prompts on wide terminals.

## Fix

Split `text` on `"\n"` before measuring and sum the physical line count of each segment independently.

## Test plan

- [ ] Verify prompts with multi-line `promptText` or `description` (containing `\n`) re-render cleanly without leaving stale lines on wide terminals.
- [ ] Verify single-line prompts are unaffected (each single segment still uses `Math.max(1, ...)` so a zero-width empty segment at end of a trailing newline counts as 1 line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)