### PR TITLE
fix: disable interactive prompting when stdin is not a TTY

### DIFF
--- a/src/api/BaseCLIFeatureOptions.ts
+++ b/src/api/BaseCLIFeatureOptions.ts
@@ -7,4 +7,5 @@ export default interface BaseCLIFeatureOptions {
   readonly completionServiceEnabled?: boolean;
   readonly imagePrinterServiceEnabled?: boolean;
   readonly validateAllCommands?: boolean;
+  readonly promptingEnabled?: boolean;
 }

--- a/src/cli/BaseCLI.ts
+++ b/src/cli/BaseCLI.ts
@@ -129,6 +129,7 @@ export default class BaseCLI implements CLI {
       completionServiceEnabled: false,
       imagePrinterServiceEnabled: false,
       validateAllCommands: false,
+      promptingEnabled: true,
       ...options,
     };
     this.#keyReader = keyReader;
@@ -219,6 +220,7 @@ export default class BaseCLI implements CLI {
       this.#keyReader,
       this.#printerService,
     );
+    prompterService.promptEnabled = this.#options.promptingEnabled;
     this.addServiceProvider(new PrompterServiceProvider(75, prompterService));
 
     if (this.#options.argumentPrompterServiceEnabled) {

--- a/src/cli/DefaultRuntimeCLI.ts
+++ b/src/cli/DefaultRuntimeCLI.ts
@@ -29,7 +29,7 @@ export default class DefaultRuntimeCLI extends BaseCLI {
         supportsHyperlinks(process.stderr),
       ),
       new TtyKeyReader(process.stdin),
-      options,
+      { promptingEnabled: process.stdin.isTTY === true, ...options },
     );
   }
 


### PR DESCRIPTION
DefaultRuntimeCLI now sets promptingEnabled: false when process.stdin.isTTY is not true, preventing CompletionServiceProvider (and other services) from hanging indefinitely waiting for input in non-interactive environments such as CI and test runners.