### PR TITLE
fix: add timeout to PowerShell spawnSync calls to prevent CI hang

### DIFF
--- a/src/service/completion/shell/powershell.ts
+++ b/src/service/completion/shell/powershell.ts
@@ -29,7 +29,7 @@ export default class PowerShellShellHandler implements ShellHandler {
 
   validateEnvironment(): Promise<boolean> {
     try {
-      const result = Bun.spawnSync(["pwsh", "--version"]);
+      const result = Bun.spawnSync(["pwsh", "--version"], { timeout: 2000 });
       if (result.exitCode === 0) {
         return Promise.resolve(true);
       }
@@ -37,7 +37,7 @@ export default class PowerShellShellHandler implements ShellHandler {
       // try powershell fallback
     }
     try {
-      const result = Bun.spawnSync(["powershell", "-Command", "echo ok"]);
+      const result = Bun.spawnSync(["powershell", "-Command", "echo ok"], { timeout: 2000 });
       return Promise.resolve(result.exitCode === 0);
     } catch {
       return Promise.resolve(false);


### PR DESCRIPTION
## Summary

- `PowerShellShellHandler.validateEnvironment()` calls `Bun.spawnSync` twice (once for `pwsh`, once for `powershell` as fallback) with no timeout
- On ubuntu-24.04 CI runners, PowerShell cold-start can exceed the 5000ms bun:test default, causing an intermittent test timeout
- Added `{ timeout: 2000 }` to both `spawnSync` calls so each attempt is capped at 2s, well within the 5s test limit

## Test plan

- [x] `bun test tests/service/completion/shell/powershell.test.ts` passes locally
- [ ] CI ubuntu-latest passes without the intermittent timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)