### PR TITLE
feat: add build step for Node.js and TypeScript consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,6 @@
 > A framework for developing CLI applications which supports dynamic discovery
 > and installation of new commands
 
-[//]: # "TODO: Remove this when plugin support."
-
-NOTE: The dynamic aspect is still in development as it relies upon:
-
-- some outstanding work on the
-  [dynamic-plugin-framework](https://github.com/flowscripter/dynamic-plugin-framework)
-  dependency.
-
-So it isn't really dynamic at the moment! 😜
-
 ## Key Features
 
 - Flexible CLI definitions:
@@ -67,10 +57,8 @@ The following example projects are available:
   application based on this framework.
 - [mpeg-sdl-tool](https://github.com/flowscripter/mpeg-sdl-tool) is a real world
   use case CLI application based on this framework.
-
-[//]: # "TODO: Add this when implemented."
-[//]: # "- [example-cli-plugin](https://github.com/flowscripter/example-cli-plugin) is an"
-[//]: # "example command and service plugin based on this framework."
+- [example-cli-plugin](https://github.com/flowscripter/example-cli-plugin) is an
+  example command and service plugin based on this framework.
 
 ## Further Details
 
@@ -78,6 +66,7 @@ The following example projects are available:
 - [Implementation Details](./README/implementation-details.md)
 - [Core Service Providers](./README/core-service-providers.md)
 - [Core Commands](./README/core-commands.md)
+- [Plugins](./README/plugins.md)
 - [Development](./README/development.md)
 - [API Documentation](https://flowscripter.github.io/dynamic-cli-framework/index.html)
 

--- a/README/development.md
+++ b/README/development.md
@@ -4,6 +4,10 @@ Install dependencies:
 
 `bun install`
 
+Build (produces `dist/` for Node.js and TypeScript consumers; Bun uses raw source directly):
+
+`bun run build`
+
 Test:
 
 `bun test`

--- a/README/development.md
+++ b/README/development.md
@@ -36,7 +36,7 @@ already installed plugins are not validated as they are loaded. The only
 validation that takes place is for commands or services provided by plugins
 BEFORE they are installed.
 
-When using `launcher.ts` runtime validation of all commands and services can be
+When using `launcher.ts` runtime validation of all commands can be
 forced by defining the `DYNAMIC_CLI_FRAMEWORK_VALIDATE_ALL` environment
 variable.
 

--- a/README/implementation-details.md
+++ b/README/implementation-details.md
@@ -54,13 +54,42 @@ classDiagram
         <<interface>>
     }
 
-    class DefaultRuntimeCLI {
-    }
-
     class CLIConfig {
     }
 
     class ServiceXYZ {
+    }
+
+    class DefaultRuntimeCLI {
+    }
+
+    class DynamicPluginRuntimeCLI {
+    }
+
+    class MarketplacePluginManager {
+        <<interface>>
+    }
+
+    class Plugin {
+        <<interface>>
+    }
+
+    class CLIPlugin {
+        <<interface>>
+    }
+
+    class CommandFactory {
+        <<interface>>
+    }
+
+    class ServiceProviderFactory {
+        <<interface>>
+    }
+
+    class HttpPluginManager {
+    }
+
+    class NpmPluginManager {
     }
 
     runner --> scanner
@@ -70,6 +99,8 @@ classDiagram
     CLI <|.. BaseCLI
 
     BaseCLI <|-- DefaultRuntimeCLI
+
+    DefaultRuntimeCLI <|-- DynamicPluginRuntimeCLI
 
     runner --> Context
 
@@ -105,7 +136,31 @@ classDiagram
 
     Context --> ServiceXYZ : access to
 
-    DefaultRuntimeCLI <-- launcher
+    DefaultRuntimeCLI <-- launcher : instantiates
+
+    DynamicPluginRuntimeCLI <-- launcher : instantiates
+
+    DefaultRuntimeCLI --> MarketplacePluginManager
+
+    CLIPlugin --> "0..1" CommandFactory : creates
+
+    CLIPlugin --> "0..1" ServiceProviderFactory : creates
+
+    Plugin <|.. CLIPlugin
+
+    MarketplacePluginManager <|.. HttpPluginManager
+
+    MarketplacePluginManager <|.. NpmPluginManager
+
+    MarketplacePluginManager --> "*" Plugin : installs and loads
+
+    DynamicPluginRuntimeCLI --> ServiceProviderRegistry : registers ServiceProviders
+
+    DynamicPluginRuntimeCLI --> CommandRegistry : registers Commands
+
+    CommandFactory --> "*" Command : builds
+
+    ServiceProviderFactory --> "*" ServiceProvider : builds
 ```
 
 ### `launcher`
@@ -161,6 +216,53 @@ documented in further detail below):
 `DefaultRuntimeCLI` is a simple extension to `BaseCLI` which uses NodeJS
 specific APIs to access the command line arguments, stdout and stderr streams
 and to exit the process.
+
+#### `DynamicPluginRuntimeCLI`
+
+`DynamicPluginRuntimeCLI` extends `DefaultRuntimeCLI` and adds dynamic plugin
+discovery. On each call to `run()` it discovers all locally installed plugins
+via the `MarketplacePluginManager` and registers their commands and service
+providers before delegating to `super.run()`. This ensures that plugin-provided
+commands and service providers participate in the full runner initialization
+lifecycle (including `GlobalModifierCommand` scanning and `initService()`).
+
+It also adds a `DefaultPluginServiceProvider` at construction time, which
+provides the `plugin` group command with `plugin:list`, `plugin:add`,
+`plugin:remove`, `plugin:search` and `plugin:upgrade` sub-commands.
+
+The following sequence diagram illustrates the plugin discovery flow in `run()`:
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant DynamicPluginRuntimeCLI
+    participant MarketplacePluginManager
+    participant CommandFactory
+    participant ServiceProviderFactory
+    participant DefaultRuntimeCLI
+
+    Caller->>DynamicPluginRuntimeCLI: run()
+    DynamicPluginRuntimeCLI->>MarketplacePluginManager: registerExtensions(COMMAND_FACTORY_EP)
+    DynamicPluginRuntimeCLI->>MarketplacePluginManager: registerExtensions(SP_FACTORY_EP)
+    DynamicPluginRuntimeCLI->>MarketplacePluginManager: getRegisteredExtensions(COMMAND_FACTORY_EP)
+    loop for each command factory extension
+        DynamicPluginRuntimeCLI->>MarketplacePluginManager: instantiate(handle)
+        MarketplacePluginManager-->>DynamicPluginRuntimeCLI: CommandFactory
+        DynamicPluginRuntimeCLI->>CommandFactory: getCommands()
+        CommandFactory-->>DynamicPluginRuntimeCLI: Command[]
+        DynamicPluginRuntimeCLI->>DynamicPluginRuntimeCLI: addCommand(cmd) for each
+    end
+    DynamicPluginRuntimeCLI->>MarketplacePluginManager: getRegisteredExtensions(SP_FACTORY_EP)
+    loop for each SP factory extension
+        DynamicPluginRuntimeCLI->>MarketplacePluginManager: instantiate(handle)
+        MarketplacePluginManager-->>DynamicPluginRuntimeCLI: ServiceProviderFactory
+        DynamicPluginRuntimeCLI->>ServiceProviderFactory: getServiceProviders()
+        ServiceProviderFactory-->>DynamicPluginRuntimeCLI: ServiceProvider[]
+        DynamicPluginRuntimeCLI->>DynamicPluginRuntimeCLI: addServiceProvider(sp) for each
+    end
+    DynamicPluginRuntimeCLI->>DefaultRuntimeCLI: super.run()
+    Note over DefaultRuntimeCLI: All plugin commands and SPs<br/>now in registries - participate<br/>in full initialization lifecycle
+```
 
 ### `runner`
 

--- a/README/implementation-details.md
+++ b/README/implementation-details.md
@@ -1,4 +1,4 @@
-# Implementation
+# Implementation Details
 
 The following diagram provides an overview of the main internal modules and
 classes:

--- a/README/key-concepts.md
+++ b/README/key-concepts.md
@@ -16,9 +16,9 @@ The key concepts are:
 - Dynamic plugins (enabled by
   [dynamic-plugin-framework](https://github.com/flowscripter/dynamic-plugin-framework))
   allow:
-  - dynamic load and import of one or more `CommandFactory` implementations
+  - dynamic load and import of `CommandFactory` implementations
     providing one or more `Command` implementations.
-  - dynamic load and import of one or more `ServiceProviderFactory`
+  - dynamic load and import of `ServiceProviderFactory`
     implementations providing one or more `ServiceProvider` implementations.
 
 The following high-level conceptual diagram illustrates these relationships:
@@ -58,6 +58,28 @@ classDiagram
         <<interface>>
     }
 
+    class Plugin {
+        <<interface>>
+    }
+
+    class CLIPlugin {
+    }
+
+    class PluginManager {
+    }
+
+    class CliPlugin {
+        <<interface>>
+    }
+
+    class CommandFactory {
+        <<interface>>
+    }
+
+    class ServiceProviderFactory {
+        <<interface>>
+    }
+
     CLI --> CLIConfig
 
     CLI --> Context
@@ -78,34 +100,21 @@ classDiagram
 
     ServiceProvider --> "*" Service : provides
 
-    class PluginManager {
-    }
-
-    class Plugin {
-        <<interface>>
-    }
-
-    CLI --> PluginManager
-
-    class CommandFactory {
-        <<interface>>
-    }
-
-    class ServiceProviderFactory {
-        <<interface>>
-    }
+    CLI --> PluginManager : uses
 
     CLI-->ServiceProviderRegistry
 
-    PluginManager --> "*" Plugin : registers
+    PluginManager --> "*" CliPlugin : registers
 
-    Plugin --> "*" CommandFactory: implements
+    Plugin <|.. CLIPlugin
 
-    Plugin --> "*" ServiceProviderFactory: implements
+    CliPlugin --> "0..1" CommandFactory : creates
 
-    CommandFactory --> "*" Command : provides
+    CliPlugin --> "0..1" ServiceProviderFactory : creates
 
-    ServiceProviderFactory --> "*" ServiceProvider : provides
+    CommandFactory --> "*" Command : builds
+
+    ServiceProviderFactory --> "*" ServiceProvider : builds
 ```
 
 ## Commands

--- a/README/plugins.md
+++ b/README/plugins.md
@@ -1,0 +1,130 @@
+# Plugins
+
+Plugin support is provided via
+[dynamic-plugin-framework](https://github.com/flowscripter/dynamic-plugin-framework).
+
+## What is a CLI plugin?
+
+A CLI plugin is a package that implements the `Plugin` interface from
+`@flowscripter/dynamic-plugin-framework` and registers extensions against one
+or both of the two CLI extension points:
+
+| Extension point constant                                         | Extension type           | Effect                                           |
+| ---------------------------------------------------------------- | ------------------------ | ------------------------------------------------ |
+| `DYNAMIC_CLI_FRAMEWORK_COMMAND_FACTORY_EXTENSION_POINT`          | `CommandFactory`         | Provides one or more `Command` instances         |
+| `DYNAMIC_CLI_FRAMEWORK_SERVICE_PROVIDER_FACTORY_EXTENSION_POINT` | `ServiceProviderFactory` | Provides one or more `ServiceProvider` instances |
+
+## Writing a plugin
+
+Import the plugin author API from the dedicated entry point:
+
+```ts
+import type {
+  CommandFactory,
+  ServiceProviderFactory,
+  SubCommand,
+  ServiceProvider,
+} from "@flowscripter/dynamic-cli-framework/plugin";
+import {
+  DYNAMIC_CLI_FRAMEWORK_COMMAND_FACTORY_EXTENSION_POINT,
+  DYNAMIC_CLI_FRAMEWORK_SERVICE_PROVIDER_FACTORY_EXTENSION_POINT,
+  ArgumentValueTypeName,
+} from "@flowscripter/dynamic-cli-framework/plugin";
+import type { Plugin, ExtensionDescriptor } from "@flowscripter/dynamic-plugin-framework";
+```
+
+Implement a `CommandFactory`:
+
+```ts
+class MyCommandFactory implements CommandFactory {
+  getCommands() {
+    return [mySubCommand];
+  }
+}
+```
+
+Implement a `ServiceProviderFactory`:
+
+```ts
+class MyServiceProviderFactory implements ServiceProviderFactory {
+  getServiceProviders() {
+    return [new MyServiceProvider()];
+  }
+}
+```
+
+Implement the plugin class and export it as the default export:
+
+```ts
+const myPlugin: Plugin = {
+  extensionDescriptors: [
+    {
+      extensionPoint: DYNAMIC_CLI_FRAMEWORK_COMMAND_FACTORY_EXTENSION_POINT,
+      factory: { create: async () => new MyCommandFactory() },
+    },
+    {
+      extensionPoint: DYNAMIC_CLI_FRAMEWORK_SERVICE_PROVIDER_FACTORY_EXTENSION_POINT,
+      factory: { create: async () => new MyServiceProviderFactory() },
+    },
+  ],
+};
+
+export default myPlugin;
+```
+
+## Enabling plugin support in a CLI
+
+Use `DynamicPluginRuntimeCLI` or the `launchDynamicPluginMultiCommandCLI` convenience
+function instead of their non-plugin counterparts:
+
+```ts
+import { launchDynamicPluginMultiCommandCLI } from "@flowscripter/dynamic-cli-framework";
+import {
+  NpmPluginManager,
+  NpmPluginRepository,
+  NpmjsPluginRepository,
+} from "@flowscripter/dynamic-plugin-framework";
+import path from "node:path";
+import os from "node:os";
+
+const pluginsDir = path.join(os.homedir(), ".my-cli", "plugins", "node_modules");
+const pluginManager = new NpmPluginManager(
+  [new NpmjsPluginRepository("mypluginframework")],
+  new NpmPluginRepository(pluginsDir, "mypluginframework"),
+);
+
+await launchDynamicPluginMultiCommandCLI(
+  pluginManager,
+  [myCommand],
+  "My CLI description",
+  "my-cli",
+  packageJson.version,
+);
+```
+
+The `NpmjsPluginRepository` keyword (`"mypluginframework"` above) is used to
+filter npm packages on the registry. Plugins should include this keyword in
+their `package.json` so they appear in search results.
+
+## Plugin management commands
+
+When plugin support is enabled, the `plugin` group command is automatically
+available:
+
+| Command                    | Description                                            |
+| -------------------------- | ------------------------------------------------------ |
+| `plugin:list`              | List locally installed plugins                         |
+| `plugin:search <query>`    | Search remote plugins                                  |
+| `plugin:add <pluginId>`    | Install a plugin (e.g. `@scope/my-plugin`)             |
+| `plugin:remove <pluginId>` | Remove an installed plugin                             |
+| `plugin:upgrade`           | Upgrade all installed plugins to their latest versions |
+
+After `plugin:add` or `plugin:upgrade`, the CLI must be restarted for the
+new or updated plugin to be active.
+
+## Example
+
+See [example-cli-plugin](https://github.com/flowscripter/example-cli-plugin)
+for a complete example plugin providing a demo command and service, and
+[example-cli](https://github.com/flowscripter/example-cli) for a CLI that
+supports installing it.

--- a/bun.lock
+++ b/bun.lock
@@ -136,7 +136,7 @@
 
     "oxlint": ["oxlint@1.71.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.71.0", "@oxlint/binding-android-arm64": "1.71.0", "@oxlint/binding-darwin-arm64": "1.71.0", "@oxlint/binding-darwin-x64": "1.71.0", "@oxlint/binding-freebsd-x64": "1.71.0", "@oxlint/binding-linux-arm-gnueabihf": "1.71.0", "@oxlint/binding-linux-arm-musleabihf": "1.71.0", "@oxlint/binding-linux-arm64-gnu": "1.71.0", "@oxlint/binding-linux-arm64-musl": "1.71.0", "@oxlint/binding-linux-ppc64-gnu": "1.71.0", "@oxlint/binding-linux-riscv64-gnu": "1.71.0", "@oxlint/binding-linux-riscv64-musl": "1.71.0", "@oxlint/binding-linux-s390x-gnu": "1.71.0", "@oxlint/binding-linux-x64-gnu": "1.71.0", "@oxlint/binding-linux-x64-musl": "1.71.0", "@oxlint/binding-openharmony-arm64": "1.71.0", "@oxlint/binding-win32-arm64-msvc": "1.71.0", "@oxlint/binding-win32-ia32-msvc": "1.71.0", "@oxlint/binding-win32-x64-msvc": "1.71.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-U1m1X+C0vDj7DC1e13IoZULzEcPczE7UOMTs8VlZGHUEIUaSTZKo5qkPsQEfzpgnQ29Pea/w3Xntk62UCecxZw=="],
 
-    "prettier": ["prettier@3.8.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q=="],
+    "prettier": ["prettier@3.9.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-HWmu+K+zvHNpaMfSnYeqdqrDbR16cuIXaPx8WoHaviQkDJh1/0BNtOZmHVQI5jc3wXv0H1yXc9wjvFdXh+n3hQ=="],
 
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
@@ -150,12 +150,8 @@
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
-    "bun-types/@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
-
     "emphasize/highlight.js": ["highlight.js@11.9.0", "", {}, "sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw=="],
 
     "lowlight/highlight.js": ["highlight.js@11.9.0", "", {}, "sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw=="],
-
-    "bun-types/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@flowscripter/dynamic-cli-framework",
       "dependencies": {
-        "@flowscripter/dynamic-plugin-framework": "../dynamic-plugin-framework",
+        "@flowscripter/dynamic-plugin-framework": "1.8.0",
         "emphasize": "^7.0.0",
         "fastest-levenshtein": "^1.0.16",
         "figlet": "^1.11.0",
@@ -26,7 +26,7 @@
     },
   },
   "packages": {
-    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@file:../dynamic-plugin-framework", { "dependencies": { "semver": "^7.8.4" }, "devDependencies": { "@types/bun": "^1.3.14", "@types/semver": "^7.7.1", "oxfmt": "0.56.0", "oxlint": "1.71.0" }, "peerDependencies": { "typescript": "^6.0.3" } }],
+    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@1.8.0", "", { "dependencies": { "semver": "^7.8.4" }, "peerDependencies": { "typescript": "^6.0.3" } }, "sha512-x7ywkhoJ6v8SyRtcZo7w5HR+o1tA0QS4i5HX8kSXRnwH84lZhWHtQjZwvyDdKfCYQpmcALwWd+C70P06Ra5zOg=="],
 
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.56.0", "", { "os": "android", "cpu": "arm" }, "sha512-CSCxi7ovYojgfdPOdUb9T508HKeAdDIKeRGg7x8IZwVJrWz9gVgX7MbUnFqtQAE4QvoNo07mj2JlwnOzJw4qqA=="],
 
@@ -109,8 +109,6 @@
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
     "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
-
-    "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@flowscripter/dynamic-cli-framework",
       "dependencies": {
+        "@flowscripter/dynamic-plugin-framework": "../dynamic-plugin-framework",
         "emphasize": "^7.0.0",
         "fastest-levenshtein": "^1.0.16",
         "figlet": "^1.11.0",
@@ -25,6 +26,8 @@
     },
   },
   "packages": {
+    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@file:../dynamic-plugin-framework", { "dependencies": { "semver": "^7.8.4" }, "devDependencies": { "@types/bun": "^1.3.14", "@types/semver": "^7.7.1", "oxfmt": "0.56.0", "oxlint": "1.71.0" }, "peerDependencies": { "typescript": "^6.0.3" } }],
+
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.56.0", "", { "os": "android", "cpu": "arm" }, "sha512-CSCxi7ovYojgfdPOdUb9T508HKeAdDIKeRGg7x8IZwVJrWz9gVgX7MbUnFqtQAE4QvoNo07mj2JlwnOzJw4qqA=="],
 
     "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.56.0", "", { "os": "android", "cpu": "arm64" }, "sha512-HYJFnd+PkDwf6S9ZPGzXXtjNqvRWFnnhdbWaouh4mi/SxU8wmDuzlMn3xo/wDTGnr4Q1VA7ZzOaE/D4biW0W6A=="],
@@ -107,6 +110,8 @@
 
     "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
 
+    "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
@@ -134,6 +139,8 @@
     "oxlint": ["oxlint@1.71.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.71.0", "@oxlint/binding-android-arm64": "1.71.0", "@oxlint/binding-darwin-arm64": "1.71.0", "@oxlint/binding-darwin-x64": "1.71.0", "@oxlint/binding-freebsd-x64": "1.71.0", "@oxlint/binding-linux-arm-gnueabihf": "1.71.0", "@oxlint/binding-linux-arm-musleabihf": "1.71.0", "@oxlint/binding-linux-arm64-gnu": "1.71.0", "@oxlint/binding-linux-arm64-musl": "1.71.0", "@oxlint/binding-linux-ppc64-gnu": "1.71.0", "@oxlint/binding-linux-riscv64-gnu": "1.71.0", "@oxlint/binding-linux-riscv64-musl": "1.71.0", "@oxlint/binding-linux-s390x-gnu": "1.71.0", "@oxlint/binding-linux-x64-gnu": "1.71.0", "@oxlint/binding-linux-x64-musl": "1.71.0", "@oxlint/binding-openharmony-arm64": "1.71.0", "@oxlint/binding-win32-arm64-msvc": "1.71.0", "@oxlint/binding-win32-ia32-msvc": "1.71.0", "@oxlint/binding-win32-x64-msvc": "1.71.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-U1m1X+C0vDj7DC1e13IoZULzEcPczE7UOMTs8VlZGHUEIUaSTZKo5qkPsQEfzpgnQ29Pea/w3Xntk62UCecxZw=="],
 
     "prettier": ["prettier@3.8.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q=="],
+
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@flowscripter/dynamic-cli-framework",
       "dependencies": {
-        "@flowscripter/dynamic-plugin-framework": "1.8.0",
+        "@flowscripter/dynamic-plugin-framework": "1.9.0",
         "emphasize": "^7.0.0",
         "fastest-levenshtein": "^1.0.16",
         "figlet": "^1.11.0",
@@ -26,7 +26,7 @@
     },
   },
   "packages": {
-    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@1.8.0", "", { "dependencies": { "semver": "^7.8.4" }, "peerDependencies": { "typescript": "^6.0.3" } }, "sha512-x7ywkhoJ6v8SyRtcZo7w5HR+o1tA0QS4i5HX8kSXRnwH84lZhWHtQjZwvyDdKfCYQpmcALwWd+C70P06Ra5zOg=="],
+    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@1.9.0", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^6.0.3" } }, "sha512-hciiMKy+Hm+mvIp3/jH9wv2C4KGjA07aYDZYWEHlGn7Xj5xfSOGYc17PzNcK4gAYqNE0eysHd5+ULJrTtVubMA=="],
 
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.56.0", "", { "os": "android", "cpu": "arm" }, "sha512-CSCxi7ovYojgfdPOdUb9T508HKeAdDIKeRGg7x8IZwVJrWz9gVgX7MbUnFqtQAE4QvoNo07mj2JlwnOzJw4qqA=="],
 

--- a/cli-plugin.ts
+++ b/cli-plugin.ts
@@ -1,0 +1,16 @@
+export type { default as CommandFactory } from "./src/api/plugin/CommandFactory.ts";
+export { DYNAMIC_CLI_FRAMEWORK_COMMAND_FACTORY_EXTENSION_POINT } from "./src/api/plugin/CommandFactory.ts";
+export type { default as ServiceProviderFactory } from "./src/api/plugin/ServiceProviderFactory.ts";
+export { DYNAMIC_CLI_FRAMEWORK_SERVICE_PROVIDER_FACTORY_EXTENSION_POINT } from "./src/api/plugin/ServiceProviderFactory.ts";
+export type { default as Command } from "./src/api/command/Command.ts";
+export type { default as SubCommand } from "./src/api/command/SubCommand.ts";
+export type { default as GlobalCommand } from "./src/api/command/GlobalCommand.ts";
+export type { default as GroupCommand } from "./src/api/command/GroupCommand.ts";
+export type { ServiceProvider, ServiceInfo } from "./src/api/service/ServiceProvider.ts";
+export type { default as Context } from "./src/api/Context.ts";
+export type { default as CLIConfig } from "./src/api/CLIConfig.ts";
+export type { ArgumentValues } from "./src/api/argument/ArgumentValueTypes.ts";
+export { ArgumentValueTypeName } from "./src/api/argument/ArgumentValueTypes.ts";
+export type { default as Option } from "./src/api/argument/Option.ts";
+export type { default as Positional } from "./src/api/argument/Positional.ts";
+export type { ExtensionDescriptor, ExtensionFactory } from "@flowscripter/dynamic-plugin-framework";

--- a/index.ts
+++ b/index.ts
@@ -168,9 +168,19 @@ export {
   MultiCommandCliHelpSubCommand,
 } from "./src/command/MultiCommandCliHelpCommand.ts";
 
+// Plugin API
+export type { default as CommandFactory } from "./src/api/plugin/CommandFactory.ts";
+export { DYNAMIC_CLI_FRAMEWORK_COMMAND_FACTORY_EXTENSION_POINT } from "./src/api/plugin/CommandFactory.ts";
+export type { default as ServiceProviderFactory } from "./src/api/plugin/ServiceProviderFactory.ts";
+export { DYNAMIC_CLI_FRAMEWORK_SERVICE_PROVIDER_FACTORY_EXTENSION_POINT } from "./src/api/plugin/ServiceProviderFactory.ts";
+export { PLUGIN_SERVICE_ID } from "./src/api/service/core/PluginService.ts";
+export type { default as PluginService } from "./src/api/service/core/PluginService.ts";
+export { default as DefaultPluginServiceProvider } from "./src/service/plugin/DefaultPluginServiceProvider.ts";
+
 // Core CLI
 export { default as BaseCLI } from "./src/cli/BaseCLI.ts";
 export { default as DefaultRuntimeCLI } from "./src/cli/DefaultRuntimeCLI.ts";
+export { default as DynamicPluginRuntimeCLI } from "./src/cli/DynamicPluginRuntimeCLI.ts";
 
 // Terminal API
 export type { default as Terminal } from "./src/terminal/Terminal.ts";
@@ -180,4 +190,8 @@ export { SpecialKey } from "./src/terminal/KeyReader.ts";
 export { default as TtyKeyReader } from "./src/terminal/TtyKeyReader.ts";
 
 // Convenience functions
-export { launchMultiCommandCLI, launchSingleCommandCLI } from "./src/launcher.ts";
+export {
+  launchMultiCommandCLI,
+  launchSingleCommandCLI,
+  launchDynamicPluginMultiCommandCLI,
+} from "./src/launcher.ts";

--- a/package.json
+++ b/package.json
@@ -17,14 +17,35 @@
     "type": "git",
     "url": "git+https://github.com/flowscripter/dynamic-cli-framework.git"
   },
+  "files": [
+    "dist",
+    "src",
+    "index.ts",
+    "cli-plugin.ts",
+    "README.md",
+    "LICENSE"
+  ],
   "type": "module",
-  "module": "index.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "exports": {
-    ".": "./index.ts",
-    "./plugin": "./cli-plugin.ts"
+    ".": {
+      "bun": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./plugin": {
+      "bun": "./cli-plugin.ts",
+      "types": "./dist/cli-plugin.d.ts",
+      "default": "./dist/cli-plugin.js"
+    }
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "bun build index.ts cli-plugin.ts --outdir dist --target bun && tsc -p tsconfig.build.json"
   },
   "dependencies": {
     "@flowscripter/dynamic-plugin-framework": "1.8.0",
@@ -39,6 +60,7 @@
   "devDependencies": {
     "@types/bun": "^1.3.14",
     "@types/node": "^26.0.1",
+    "@types/semver": "^7.7.1",
     "oxfmt": "0.56.0",
     "oxlint": "1.71.0"
   },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "build": "bun build index.ts cli-plugin.ts --outdir dist --target bun && tsc -p tsconfig.build.json"
   },
   "dependencies": {
-    "@flowscripter/dynamic-plugin-framework": "1.8.0",
+    "@flowscripter/dynamic-plugin-framework": "1.9.0",
     "emphasize": "^7.0.0",
     "fastest-levenshtein": "^1.0.16",
     "figlet": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,15 @@
   },
   "type": "module",
   "module": "index.ts",
+  "exports": {
+    ".": "./index.ts",
+    "./plugin": "./cli-plugin.ts"
+  },
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
+    "@flowscripter/dynamic-plugin-framework": "../dynamic-plugin-framework",
     "emphasize": "^7.0.0",
     "fastest-levenshtein": "^1.0.16",
     "figlet": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@flowscripter/dynamic-plugin-framework": "../dynamic-plugin-framework",
+    "@flowscripter/dynamic-plugin-framework": "1.8.0",
     "emphasize": "^7.0.0",
     "fastest-levenshtein": "^1.0.16",
     "figlet": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
   "devDependencies": {
     "@types/bun": "^1.3.14",
     "@types/node": "^26.0.1",
-    "@types/semver": "^7.7.1",
     "oxfmt": "0.56.0",
     "oxlint": "1.71.0"
   },

--- a/src/api/plugin/CommandFactory.ts
+++ b/src/api/plugin/CommandFactory.ts
@@ -1,0 +1,25 @@
+import type Command from "../command/Command.ts";
+
+/**
+ * Extension point identifier for {@link CommandFactory} extensions.
+ *
+ * Plugins register against this extension point to supply {@link Command} instances
+ * that are added to the CLI before execution begins.
+ */
+export const DYNAMIC_CLI_FRAMEWORK_COMMAND_FACTORY_EXTENSION_POINT =
+  "DYNAMIC_CLI_FRAMEWORK_COMMAND_FACTORY";
+
+/**
+ * Extension interface implemented by a plugin to provide {@link Command} instances.
+ *
+ * A plugin registers an {@link CommandFactory} against
+ * {@link DYNAMIC_CLI_FRAMEWORK_COMMAND_FACTORY_EXTENSION_POINT}. On startup,
+ * {@link DynamicPluginRuntimeCLI} instantiates each factory and adds the returned
+ * commands to the CLI registry before the runner executes.
+ */
+export default interface CommandFactory {
+  /**
+   * Return the {@link Command} instances provided by this factory.
+   */
+  getCommands(): ReadonlyArray<Command>;
+}

--- a/src/api/plugin/ServiceProviderFactory.ts
+++ b/src/api/plugin/ServiceProviderFactory.ts
@@ -1,0 +1,27 @@
+import type { ServiceProvider } from "../service/ServiceProvider.ts";
+
+/**
+ * Extension point identifier for {@link ServiceProviderFactory} extensions.
+ *
+ * Plugins register against this extension point to supply {@link ServiceProvider} instances
+ * that are initialised by the runner as part of the normal service lifecycle.
+ */
+export const DYNAMIC_CLI_FRAMEWORK_SERVICE_PROVIDER_FACTORY_EXTENSION_POINT =
+  "DYNAMIC_CLI_FRAMEWORK_SERVICE_PROVIDER_FACTORY";
+
+/**
+ * Extension interface implemented by a plugin to provide {@link ServiceProvider} instances.
+ *
+ * A plugin registers a {@link ServiceProviderFactory} against
+ * {@link DYNAMIC_CLI_FRAMEWORK_SERVICE_PROVIDER_FACTORY_EXTENSION_POINT}. On startup,
+ * {@link DynamicPluginRuntimeCLI} instantiates each factory and adds the returned
+ * service providers to the CLI registry before the runner executes, so they participate
+ * in the full initialization lifecycle (including {@link GlobalModifierCommand} scanning
+ * and {@link ServiceProvider.initService}).
+ */
+export default interface ServiceProviderFactory {
+  /**
+   * Return the {@link ServiceProvider} instances provided by this factory.
+   */
+  getServiceProviders(): ReadonlyArray<ServiceProvider>;
+}

--- a/src/api/service/core/PluginService.ts
+++ b/src/api/service/core/PluginService.ts
@@ -1,0 +1,63 @@
+import type {
+  VersionedPluginDescriptor,
+  SearchQuery,
+} from "@flowscripter/dynamic-plugin-framework";
+
+/**
+ * Service ID for {@link PluginService}.
+ *
+ * Pass to {@link Context.getServiceById} to retrieve the active {@link PluginService} instance.
+ */
+export const PLUGIN_SERVICE_ID = "PLUGIN_SERVICE";
+
+/**
+ * Service providing plugin lifecycle management for a CLI with dynamic plugin support.
+ *
+ * Exposes search, install, uninstall, list, and update operations backed by a
+ * {@link MarketplacePluginManager}. Provided by {@link DefaultPluginServiceProvider}
+ * when plugin support is enabled via {@link DynamicPluginRuntimeCLI}.
+ *
+ * After {@link install} or an upgrade, the CLI must be restarted for new or updated
+ * plugin commands and service providers to become active.
+ */
+export default interface PluginService {
+  /**
+   * Search the remote marketplace for plugins matching the given query.
+   *
+   * @param query criteria to filter results by.
+   * @returns an async iterable of matching {@link VersionedPluginDescriptor} entries.
+   */
+  search(query: Readonly<SearchQuery>): AsyncIterable<Readonly<VersionedPluginDescriptor>>;
+
+  /**
+   * Install a plugin from the remote marketplace into the local plugin store.
+   *
+   * @param descriptor the plugin to install, as returned by {@link search}.
+   */
+  install(descriptor: Readonly<VersionedPluginDescriptor>): Promise<void>;
+
+  /**
+   * Remove a previously installed plugin from the local plugin store.
+   *
+   * @param pluginId the package identifier of the plugin to remove (e.g. `@scope/my-plugin`).
+   */
+  uninstall(pluginId: string): Promise<void>;
+
+  /**
+   * List all plugins currently installed in the local plugin store.
+   *
+   * @returns an async iterable of {@link VersionedPluginDescriptor} entries for each installed plugin.
+   */
+  listInstalled(): AsyncIterable<Readonly<VersionedPluginDescriptor>>;
+
+  /**
+   * Check each installed plugin for a newer version available on the remote marketplace.
+   *
+   * @returns an async iterable of objects pairing the installed plugin descriptor with the
+   * latest available version string for plugins that have an update available.
+   */
+  checkForUpdates(): AsyncIterable<{
+    descriptor: Readonly<VersionedPluginDescriptor>;
+    availableVersion: string;
+  }>;
+}

--- a/src/cli/DynamicPluginRuntimeCLI.ts
+++ b/src/cli/DynamicPluginRuntimeCLI.ts
@@ -1,0 +1,77 @@
+import type { MarketplacePluginManager } from "@flowscripter/dynamic-plugin-framework";
+import type CLIConfig from "../api/CLIConfig.ts";
+import type BaseCLIFeatureOptions from "../api/BaseCLIFeatureOptions.ts";
+import type RunResult from "../api/RunResult.ts";
+import { RunState } from "../api/RunResult.ts";
+import DefaultRuntimeCLI from "./DefaultRuntimeCLI.ts";
+import DefaultPluginServiceProvider from "../service/plugin/DefaultPluginServiceProvider.ts";
+import { DYNAMIC_CLI_FRAMEWORK_COMMAND_FACTORY_EXTENSION_POINT } from "../api/plugin/CommandFactory.ts";
+import { DYNAMIC_CLI_FRAMEWORK_SERVICE_PROVIDER_FACTORY_EXTENSION_POINT } from "../api/plugin/ServiceProviderFactory.ts";
+import type CommandFactory from "../api/plugin/CommandFactory.ts";
+import type ServiceProviderFactory from "../api/plugin/ServiceProviderFactory.ts";
+import process from "node:process";
+
+/**
+ * Extension of {@link DefaultRuntimeCLI} that discovers and loads installed plugins before running.
+ *
+ * On each invocation of {@link run}, all locally installed plugins are discovered via the
+ * {@link MarketplacePluginManager}. Commands provided by {@link CommandFactory} extensions and
+ * service providers provided by {@link ServiceProviderFactory} extensions are registered before
+ * the runner starts, so they participate in the full initialization lifecycle.
+ */
+export default class DynamicPluginRuntimeCLI extends DefaultRuntimeCLI {
+  readonly #pluginManager: MarketplacePluginManager;
+
+  constructor(
+    cliConfig: CLIConfig,
+    pluginManager: MarketplacePluginManager,
+    options?: BaseCLIFeatureOptions,
+  ) {
+    super(cliConfig, options);
+    this.#pluginManager = pluginManager;
+    this.addServiceProvider(new DefaultPluginServiceProvider(pluginManager));
+  }
+
+  override async run(): Promise<RunResult> {
+    try {
+      await this.loadPlugins();
+    } catch (err) {
+      console.error(err);
+      process.exit(RunState.RUNTIME_ERROR);
+    }
+    return super.run();
+  }
+
+  async loadPlugins(): Promise<void> {
+    await this.#pluginManager.registerExtensions(
+      DYNAMIC_CLI_FRAMEWORK_COMMAND_FACTORY_EXTENSION_POINT,
+    );
+    await this.#pluginManager.registerExtensions(
+      DYNAMIC_CLI_FRAMEWORK_SERVICE_PROVIDER_FACTORY_EXTENSION_POINT,
+    );
+
+    const commandFactoryExtensions = await this.#pluginManager.getRegisteredExtensions(
+      DYNAMIC_CLI_FRAMEWORK_COMMAND_FACTORY_EXTENSION_POINT,
+    );
+    for (const ext of commandFactoryExtensions) {
+      const factory = (await this.#pluginManager.instantiate(
+        ext.extensionHandle,
+      )) as CommandFactory;
+      for (const command of factory.getCommands()) {
+        this.addCommand(command);
+      }
+    }
+
+    const spFactoryExtensions = await this.#pluginManager.getRegisteredExtensions(
+      DYNAMIC_CLI_FRAMEWORK_SERVICE_PROVIDER_FACTORY_EXTENSION_POINT,
+    );
+    for (const ext of spFactoryExtensions) {
+      const factory = (await this.#pluginManager.instantiate(
+        ext.extensionHandle,
+      )) as ServiceProviderFactory;
+      for (const sp of factory.getServiceProviders()) {
+        this.addServiceProvider(sp);
+      }
+    }
+  }
+}

--- a/src/command/PluginCommand.ts
+++ b/src/command/PluginCommand.ts
@@ -1,0 +1,187 @@
+import type GroupCommand from "../api/command/GroupCommand.ts";
+import type SubCommand from "../api/command/SubCommand.ts";
+import type Context from "../api/Context.ts";
+import type { ArgumentValues } from "../api/argument/ArgumentValueTypes.ts";
+import { ArgumentValueTypeName } from "../api/argument/ArgumentValueTypes.ts";
+import type PrinterService from "../api/service/core/PrinterService.ts";
+import { Icon, PRINTER_SERVICE_ID } from "../api/service/core/PrinterService.ts";
+import { PLUGIN_SERVICE_ID } from "../api/service/core/PluginService.ts";
+import type PluginService from "../api/service/core/PluginService.ts";
+import type { VersionedPluginDescriptor } from "@flowscripter/dynamic-plugin-framework";
+
+function getPluginId(descriptor: VersionedPluginDescriptor): string {
+  return descriptor.scope ? `@${descriptor.scope}/${descriptor.name}` : descriptor.name;
+}
+
+export class PluginListSubCommand implements SubCommand {
+  readonly name = "list";
+  readonly description = "List locally installed plugins";
+  readonly enableConfiguration = false;
+  readonly options = [];
+  readonly positionals = [];
+
+  async execute(context: Context, _argumentValues: ArgumentValues): Promise<void> {
+    const printerService = context.getServiceById(PRINTER_SERVICE_ID) as PrinterService;
+    const pluginService = context.getServiceById(PLUGIN_SERVICE_ID) as PluginService;
+
+    let found = false;
+    for await (const descriptor of pluginService.listInstalled()) {
+      if (!found) {
+        found = true;
+        await printerService.print("Installed plugins:\n");
+      }
+      await printerService.print(`  ${getPluginId(descriptor)}  ${descriptor.version}\n`);
+    }
+    if (!found) {
+      await printerService.print("No plugins installed.\n");
+    }
+  }
+}
+
+export class PluginSearchSubCommand implements SubCommand {
+  readonly name = "search";
+  readonly description = "Search remote plugins";
+  readonly enableConfiguration = false;
+  readonly options = [];
+  readonly positionals = [
+    {
+      name: "query",
+      description: "Search query",
+      type: ArgumentValueTypeName.STRING,
+      isVarargOptional: true,
+    },
+  ];
+
+  async execute(context: Context, argumentValues: ArgumentValues): Promise<void> {
+    const printerService = context.getServiceById(PRINTER_SERVICE_ID) as PrinterService;
+    const pluginService = context.getServiceById(PLUGIN_SERVICE_ID) as PluginService;
+
+    const query = (argumentValues["query"] as string | undefined) ?? "";
+    let found = false;
+    for await (const descriptor of pluginService.search({ text: query })) {
+      if (!found) {
+        found = true;
+        await printerService.print("Available plugins:\n");
+      }
+      await printerService.print(`  ${getPluginId(descriptor)}  ${descriptor.version}\n`);
+    }
+    if (!found) {
+      await printerService.print("No plugins found.\n");
+    }
+  }
+}
+
+export class PluginAddSubCommand implements SubCommand {
+  readonly name = "add";
+  readonly description = "Install a remote plugin";
+  readonly enableConfiguration = false;
+  readonly options = [];
+  readonly positionals = [
+    {
+      name: "pluginId",
+      description: "Plugin ID to install (e.g. @scope/name)",
+      type: ArgumentValueTypeName.STRING,
+    },
+  ];
+
+  async execute(context: Context, argumentValues: ArgumentValues): Promise<void> {
+    const printerService = context.getServiceById(PRINTER_SERVICE_ID) as PrinterService;
+    const pluginService = context.getServiceById(PLUGIN_SERVICE_ID) as PluginService;
+
+    const pluginId = argumentValues["pluginId"] as string;
+    await printerService.info(`Searching for plugin: ${pluginId}`, Icon.INFORMATION);
+
+    let descriptor: VersionedPluginDescriptor | undefined;
+    for await (const d of pluginService.search({ text: pluginId })) {
+      if (getPluginId(d) === pluginId || d.pluginId === pluginId) {
+        descriptor = d;
+        break;
+      }
+    }
+    if (!descriptor) {
+      await printerService.error(`Plugin not found: ${pluginId}`, Icon.FAILURE);
+      return;
+    }
+
+    await printerService.info(
+      `Installing ${getPluginId(descriptor)}@${descriptor.version}...`,
+      Icon.INFORMATION,
+    );
+    await pluginService.install(descriptor);
+    await printerService.print(
+      `Plugin ${getPluginId(descriptor)} installed.\n`,
+      Icon.SUCCESS,
+    );
+  }
+}
+
+export class PluginRemoveSubCommand implements SubCommand {
+  readonly name = "remove";
+  readonly description = "Remove a locally installed plugin";
+  readonly enableConfiguration = false;
+  readonly options = [];
+  readonly positionals = [
+    {
+      name: "pluginId",
+      description: "Plugin ID to remove (e.g. @scope/name)",
+      type: ArgumentValueTypeName.STRING,
+    },
+  ];
+
+  async execute(context: Context, argumentValues: ArgumentValues): Promise<void> {
+    const printerService = context.getServiceById(PRINTER_SERVICE_ID) as PrinterService;
+    const pluginService = context.getServiceById(PLUGIN_SERVICE_ID) as PluginService;
+
+    const pluginId = argumentValues["pluginId"] as string;
+    await printerService.info(`Removing plugin: ${pluginId}...`, Icon.INFORMATION);
+    await pluginService.uninstall(pluginId);
+    await printerService.print(`Plugin ${pluginId} removed.\n`, Icon.SUCCESS);
+  }
+}
+
+export class PluginUpgradeSubCommand implements SubCommand {
+  readonly name = "upgrade";
+  readonly description = "Upgrade locally installed plugins";
+  readonly enableConfiguration = false;
+  readonly options = [];
+  readonly positionals = [];
+
+  async execute(context: Context, _argumentValues: ArgumentValues): Promise<void> {
+    const printerService = context.getServiceById(PRINTER_SERVICE_ID) as PrinterService;
+    const pluginService = context.getServiceById(PLUGIN_SERVICE_ID) as PluginService;
+
+    let upgraded = 0;
+    for await (const update of pluginService.checkForUpdates()) {
+      const id = getPluginId(update.descriptor);
+      await printerService.info(
+        `Upgrading ${id} to ${update.availableVersion}...`,
+        Icon.INFORMATION,
+      );
+      await pluginService.install(update.descriptor);
+      await printerService.print(`Upgraded ${id} to ${update.availableVersion}.\n`, Icon.SUCCESS);
+      upgraded++;
+    }
+    if (upgraded === 0) {
+      await printerService.print("All plugins are up to date.\n");
+    }
+  }
+}
+
+export class PluginGroupCommand implements GroupCommand {
+  readonly name = "plugin";
+  readonly description = "Manage CLI plugins";
+  readonly enableConfiguration = false;
+  readonly memberSubCommands: ReadonlyArray<SubCommand>;
+
+  constructor() {
+    this.memberSubCommands = [
+      new PluginListSubCommand(),
+      new PluginSearchSubCommand(),
+      new PluginAddSubCommand(),
+      new PluginRemoveSubCommand(),
+      new PluginUpgradeSubCommand(),
+    ];
+  }
+
+  async execute(_context: Context): Promise<void> {}
+}

--- a/src/command/PluginCommand.ts
+++ b/src/command/PluginCommand.ts
@@ -108,10 +108,7 @@ export class PluginAddSubCommand implements SubCommand {
       Icon.INFORMATION,
     );
     await pluginService.install(descriptor);
-    await printerService.print(
-      `Plugin ${getPluginId(descriptor)} installed.\n`,
-      Icon.SUCCESS,
-    );
+    await printerService.print(`Plugin ${getPluginId(descriptor)} installed.\n`, Icon.SUCCESS);
   }
 }
 

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -4,9 +4,11 @@ import type CLIConfig from "./api/CLIConfig.ts";
 import type BaseCLIFeatureOptions from "./api/BaseCLIFeatureOptions.ts";
 import type SubCommand from "./api/command/SubCommand.ts";
 import DefaultRuntimeCLI from "./cli/DefaultRuntimeCLI.ts";
+import DynamicPluginRuntimeCLI from "./cli/DynamicPluginRuntimeCLI.ts";
 import type Command from "./api/command/Command.ts";
 import type RunResult from "./api/RunResult.ts";
 import type { ServiceProvider } from "./api/service/ServiceProvider.ts";
+import type { MarketplacePluginManager } from "@flowscripter/dynamic-plugin-framework";
 
 export async function launchSingleCommandCLI(
   command: SubCommand,
@@ -64,6 +66,39 @@ export async function launchMultiCommandCLI(
       process.env.DYNAMIC_CLI_FRAMEWORK_VALIDATE_ALL !== undefined,
   };
   const cli = new DefaultRuntimeCLI(cliConfig, mergedOptions);
+
+  commands.forEach((command) => cli.addCommand(command));
+
+  serviceProviders?.forEach((service) => cli.addServiceProvider(service));
+
+  return await cli.run();
+}
+
+export async function launchDynamicPluginMultiCommandCLI(
+  pluginManager: MarketplacePluginManager,
+  commands: ReadonlyArray<Command>,
+  description?: string,
+  name?: string,
+  version?: string,
+  serviceProviders?: ReadonlyArray<ServiceProvider>,
+  options?: BaseCLIFeatureOptions,
+): Promise<RunResult> {
+  if (!name) {
+    name = path.basename(process.execPath);
+  }
+  const cliConfig: CLIConfig = {
+    description,
+    name,
+    version: version || "N/A",
+  };
+
+  const mergedOptions: BaseCLIFeatureOptions = {
+    ...options,
+    validateAllCommands:
+      (options?.validateAllCommands ?? false) ||
+      process.env.DYNAMIC_CLI_FRAMEWORK_VALIDATE_ALL !== undefined,
+  };
+  const cli = new DynamicPluginRuntimeCLI(cliConfig, pluginManager, mergedOptions);
 
   commands.forEach((command) => cli.addCommand(command));
 

--- a/src/service/plugin/DefaultPluginService.ts
+++ b/src/service/plugin/DefaultPluginService.ts
@@ -1,0 +1,37 @@
+import type PluginService from "../../api/service/core/PluginService.ts";
+import type {
+  MarketplacePluginManager,
+  VersionedPluginDescriptor,
+  SearchQuery,
+} from "@flowscripter/dynamic-plugin-framework";
+
+export default class DefaultPluginService implements PluginService {
+  readonly #pluginManager: MarketplacePluginManager;
+
+  constructor(pluginManager: MarketplacePluginManager) {
+    this.#pluginManager = pluginManager;
+  }
+
+  search(query: Readonly<SearchQuery>): AsyncIterable<Readonly<VersionedPluginDescriptor>> {
+    return this.#pluginManager.search(query);
+  }
+
+  async install(descriptor: Readonly<VersionedPluginDescriptor>): Promise<void> {
+    await this.#pluginManager.install(descriptor);
+  }
+
+  async uninstall(pluginId: string): Promise<void> {
+    await this.#pluginManager.uninstall(pluginId);
+  }
+
+  listInstalled(): AsyncIterable<Readonly<VersionedPluginDescriptor>> {
+    return this.#pluginManager.listInstalled();
+  }
+
+  checkForUpdates(): AsyncIterable<{
+    descriptor: Readonly<VersionedPluginDescriptor>;
+    availableVersion: string;
+  }> {
+    return this.#pluginManager.checkForUpdates();
+  }
+}

--- a/src/service/plugin/DefaultPluginServiceProvider.ts
+++ b/src/service/plugin/DefaultPluginServiceProvider.ts
@@ -1,0 +1,29 @@
+import type { ServiceProvider, ServiceInfo } from "../../api/service/ServiceProvider.ts";
+import type Context from "../../api/Context.ts";
+import type CLIConfig from "../../api/CLIConfig.ts";
+import type { MarketplacePluginManager } from "@flowscripter/dynamic-plugin-framework";
+import { PLUGIN_SERVICE_ID } from "../../api/service/core/PluginService.ts";
+import DefaultPluginService from "./DefaultPluginService.ts";
+import { PluginGroupCommand } from "../../command/PluginCommand.ts";
+
+export default class DefaultPluginServiceProvider implements ServiceProvider {
+  readonly serviceId = PLUGIN_SERVICE_ID;
+  readonly servicePriority: number;
+  readonly #pluginManager: MarketplacePluginManager;
+  #pluginService: DefaultPluginService | undefined;
+
+  constructor(pluginManager: MarketplacePluginManager, servicePriority = 50) {
+    this.#pluginManager = pluginManager;
+    this.servicePriority = servicePriority;
+  }
+
+  async getServiceInfo(_cliConfig: CLIConfig): Promise<ServiceInfo> {
+    this.#pluginService = new DefaultPluginService(this.#pluginManager);
+    return {
+      service: this.#pluginService,
+      commands: [new PluginGroupCommand()],
+    };
+  }
+
+  async initService(_context: Context): Promise<void> {}
+}

--- a/tests/cli/DynamicPluginRuntimeCLI.test.ts
+++ b/tests/cli/DynamicPluginRuntimeCLI.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test";
+import type { MarketplacePluginManager } from "@flowscripter/dynamic-plugin-framework";
+import DynamicPluginRuntimeCLI from "../../src/cli/DynamicPluginRuntimeCLI.ts";
+import type CLIConfig from "../../src/api/CLIConfig.ts";
+import type CommandFactory from "../../src/api/plugin/CommandFactory.ts";
+import type ServiceProviderFactory from "../../src/api/plugin/ServiceProviderFactory.ts";
+import { DYNAMIC_CLI_FRAMEWORK_COMMAND_FACTORY_EXTENSION_POINT } from "../../src/api/plugin/CommandFactory.ts";
+import { DYNAMIC_CLI_FRAMEWORK_SERVICE_PROVIDER_FACTORY_EXTENSION_POINT } from "../../src/api/plugin/ServiceProviderFactory.ts";
+import type SubCommand from "../../src/api/command/SubCommand.ts";
+import type { ServiceProvider, ServiceInfo } from "../../src/api/service/ServiceProvider.ts";
+import type Context from "../../src/api/Context.ts";
+import type { ArgumentValues } from "../../src/api/argument/ArgumentValueTypes.ts";
+import { ArgumentValueTypeName } from "../../src/api/argument/ArgumentValueTypes.ts";
+import { PLUGIN_SERVICE_ID } from "../../src/api/service/core/PluginService.ts";
+
+function getCLIConfig(): CLIConfig {
+  return { name: "testcli", description: "Test CLI", version: "1.0.0" };
+}
+
+const pluginSubCommand: SubCommand = {
+  name: "plugin-demo",
+  description: "Demo command from plugin",
+  enableConfiguration: false,
+  options: [],
+  positionals: [
+    {
+      name: "val",
+      description: "value",
+      type: ArgumentValueTypeName.STRING,
+      isVarargOptional: true,
+    },
+  ],
+  execute: (_context: Context, _argumentValues: ArgumentValues) => Promise.resolve(),
+};
+
+const pluginCommandFactory: CommandFactory = {
+  getCommands: () => [pluginSubCommand],
+};
+
+const pluginServiceProvider: ServiceProvider = {
+  serviceId: "PLUGIN_DEMO_SERVICE",
+  servicePriority: 10,
+  getServiceInfo: (_cliConfig: CLIConfig): Promise<ServiceInfo> =>
+    Promise.resolve({ service: {}, commands: [] }),
+  initService: (_context: Context) => Promise.resolve(),
+};
+
+const pluginServiceProviderFactory: ServiceProviderFactory = {
+  getServiceProviders: () => [pluginServiceProvider],
+};
+
+function makeMockPluginManager(opts: {
+  commandFactoryHandle?: string;
+  spFactoryHandle?: string;
+}): MarketplacePluginManager {
+  return {
+    search: async function* () {},
+    install: async () => {},
+    uninstall: async () => {},
+    listInstalled: async function* () {},
+    checkForUpdates: async function* () {},
+    registerExtensions: async () => {},
+    getRegisteredExtensions: async (ep: string) => {
+      if (
+        ep === DYNAMIC_CLI_FRAMEWORK_COMMAND_FACTORY_EXTENSION_POINT &&
+        opts.commandFactoryHandle
+      ) {
+        return [{ extensionHandle: opts.commandFactoryHandle }];
+      }
+      if (
+        ep === DYNAMIC_CLI_FRAMEWORK_SERVICE_PROVIDER_FACTORY_EXTENSION_POINT &&
+        opts.spFactoryHandle
+      ) {
+        return [{ extensionHandle: opts.spFactoryHandle }];
+      }
+      return [];
+    },
+    instantiate: async (handle: string) => {
+      if (handle === opts.commandFactoryHandle) return pluginCommandFactory;
+      if (handle === opts.spFactoryHandle) return pluginServiceProviderFactory;
+      throw new Error(`Unknown handle: ${handle}`);
+    },
+  } as unknown as MarketplacePluginManager;
+}
+
+// Tests call loadPlugins() directly to avoid the process.exit() in DefaultRuntimeCLI.run().
+// The integration of the full run() lifecycle is covered by functional tests.
+
+describe("DynamicPluginRuntimeCLI", () => {
+  test("constructs without error and registers DefaultPluginServiceProvider", () => {
+    const cli = new DynamicPluginRuntimeCLI(getCLIConfig(), makeMockPluginManager({}));
+    expect(cli).toBeInstanceOf(DynamicPluginRuntimeCLI);
+  });
+
+  test("loadPlugins() registers both extension points", async () => {
+    const registered: string[] = [];
+    const manager = {
+      ...makeMockPluginManager({}),
+      registerExtensions: async (ep: string) => {
+        registered.push(ep);
+      },
+    } as unknown as MarketplacePluginManager;
+    const cli = new DynamicPluginRuntimeCLI(getCLIConfig(), manager);
+    await cli.loadPlugins();
+    expect(registered).toContain(DYNAMIC_CLI_FRAMEWORK_COMMAND_FACTORY_EXTENSION_POINT);
+    expect(registered).toContain(DYNAMIC_CLI_FRAMEWORK_SERVICE_PROVIDER_FACTORY_EXTENSION_POINT);
+  });
+
+  test("loadPlugins() adds commands from a CommandFactory extension", async () => {
+    const addedCommands: string[] = [];
+    const originalAddCommand = DynamicPluginRuntimeCLI.prototype.addCommand;
+    DynamicPluginRuntimeCLI.prototype.addCommand = function (cmd) {
+      addedCommands.push(cmd.name);
+      return originalAddCommand.call(this, cmd);
+    };
+
+    const manager = makeMockPluginManager({ commandFactoryHandle: "0:test-plugin:cmd" });
+    const cli = new DynamicPluginRuntimeCLI(getCLIConfig(), manager);
+    await cli.loadPlugins();
+
+    DynamicPluginRuntimeCLI.prototype.addCommand = originalAddCommand;
+    expect(addedCommands).toContain("plugin-demo");
+  });
+
+  test("loadPlugins() adds service providers from a ServiceProviderFactory extension", async () => {
+    const addedProviders: string[] = [];
+    const originalAddSP = DynamicPluginRuntimeCLI.prototype.addServiceProvider;
+    DynamicPluginRuntimeCLI.prototype.addServiceProvider = function (sp) {
+      addedProviders.push(sp.serviceId);
+      return originalAddSP.call(this, sp);
+    };
+
+    const manager = makeMockPluginManager({ spFactoryHandle: "0:test-plugin:sp" });
+    const cli = new DynamicPluginRuntimeCLI(getCLIConfig(), manager);
+    await cli.loadPlugins();
+
+    DynamicPluginRuntimeCLI.prototype.addServiceProvider = originalAddSP;
+    expect(addedProviders).toContain(PLUGIN_SERVICE_ID);
+    expect(addedProviders).toContain("PLUGIN_DEMO_SERVICE");
+  });
+
+  test("loadPlugins() throws when a factory instantiation fails", async () => {
+    const manager = {
+      ...makeMockPluginManager({ commandFactoryHandle: "bad-handle" }),
+      instantiate: async () => {
+        throw new Error("load error");
+      },
+    } as unknown as MarketplacePluginManager;
+    const cli = new DynamicPluginRuntimeCLI(getCLIConfig(), manager);
+    expect(cli.loadPlugins()).rejects.toThrow("load error");
+  });
+});

--- a/tests/service/plugin/DefaultPluginServiceProvider.test.ts
+++ b/tests/service/plugin/DefaultPluginServiceProvider.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import DefaultPluginServiceProvider from "../../../src/service/plugin/DefaultPluginServiceProvider.ts";
+import { PLUGIN_SERVICE_ID } from "../../../src/api/service/core/PluginService.ts";
+import type { MarketplacePluginManager } from "@flowscripter/dynamic-plugin-framework";
+import type CLIConfig from "../../../src/api/CLIConfig.ts";
+import DefaultContext from "../../../src/runtime/DefaultContext.ts";
+import { PluginGroupCommand } from "../../../src/command/PluginCommand.ts";
+
+function getCLIConfig(): CLIConfig {
+  return { name: "testcli", description: "Test CLI", version: "1.0.0" };
+}
+
+function makeMockPluginManager(): MarketplacePluginManager {
+  return {
+    search: async function* () {},
+    install: async () => {},
+    uninstall: async () => {},
+    listInstalled: async function* () {},
+    checkForUpdates: async function* () {},
+    registerExtensions: async () => {},
+    getRegisteredExtensions: async () => [],
+    instantiate: async () => ({}),
+  } as unknown as MarketplacePluginManager;
+}
+
+describe("DefaultPluginServiceProvider", () => {
+  test("has correct serviceId", () => {
+    const provider = new DefaultPluginServiceProvider(makeMockPluginManager());
+    expect(provider.serviceId).toEqual(PLUGIN_SERVICE_ID);
+  });
+
+  test("has correct default servicePriority", () => {
+    const provider = new DefaultPluginServiceProvider(makeMockPluginManager());
+    expect(provider.servicePriority).toEqual(50);
+  });
+
+  test("respects custom servicePriority", () => {
+    const provider = new DefaultPluginServiceProvider(makeMockPluginManager(), 30);
+    expect(provider.servicePriority).toEqual(30);
+  });
+
+  test("getServiceInfo returns a PluginService instance", async () => {
+    const provider = new DefaultPluginServiceProvider(makeMockPluginManager());
+    const info = await provider.getServiceInfo(getCLIConfig());
+    expect(info.service).toBeDefined();
+  });
+
+  test("getServiceInfo returns a single plugin GroupCommand", async () => {
+    const provider = new DefaultPluginServiceProvider(makeMockPluginManager());
+    const info = await provider.getServiceInfo(getCLIConfig());
+    expect(info.commands).toHaveLength(1);
+    expect(info.commands[0]).toBeInstanceOf(PluginGroupCommand);
+    expect(info.commands[0]!.name).toEqual("plugin");
+  });
+
+  test("plugin GroupCommand has 5 member sub-commands", async () => {
+    const provider = new DefaultPluginServiceProvider(makeMockPluginManager());
+    const info = await provider.getServiceInfo(getCLIConfig());
+    const group = info.commands[0] as PluginGroupCommand;
+    expect(group.memberSubCommands).toHaveLength(5);
+    const names = group.memberSubCommands.map((c) => c.name);
+    expect(names).toContain("list");
+    expect(names).toContain("search");
+    expect(names).toContain("add");
+    expect(names).toContain("remove");
+    expect(names).toContain("upgrade");
+  });
+
+  test("initService completes without error", async () => {
+    const provider = new DefaultPluginServiceProvider(makeMockPluginManager());
+    const context = new DefaultContext(getCLIConfig());
+    await provider.initService(context);
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rewriteRelativeImportExtensions": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,5 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false
-  },
-  "exclude": ["tests"]
+  }
 }


### PR DESCRIPTION
## Summary

- Add `bun run build` script: runs `bun build index.ts cli-plugin.ts --outdir dist --target bun` then `tsc -p tsconfig.build.json`
- Add `tsconfig.build.json` extending the base config with `emitDeclarationOnly`, `declaration`, `declarationMap`, `rewriteRelativeImportExtensions`, and `outDir: dist`
- Update `package.json` with `main`, `types`, dual-entry `exports` (with `bun` condition for raw source on both `.` and `./plugin`), and `files` fields
- Update development docs with build step

Bun consumers use raw `.ts` source via the `bun` exports condition. Node.js and TypeScript consumers use `dist/index.js` / `dist/cli-plugin.js` and corresponding `.d.ts` files.

## Test plan

- [ ] `bun install && bun run build` produces `dist/index.js`, `dist/cli-plugin.js`, `dist/index.d.ts`, `dist/cli-plugin.d.ts`
- [ ] CI workflow runs `bun run build` before semantic-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)