### PR TITLE
fix: resolve npm/bun .cmd shims through cmd.exe on Windows in spawn service

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@flowscripter/dynamic-cli-framework",
       "dependencies": {
         "@flowscripter/dynamic-cli-framework-api": "^1.2.0",
-        "@flowscripter/dynamic-plugin-framework": "1.11.0",
+        "@flowscripter/dynamic-plugin-framework": "1.11.1",
         "emphasize": "^7.0.0",
         "fastest-levenshtein": "^1.0.16",
         "figlet": "^1.11.0",
@@ -31,7 +31,7 @@
   "packages": {
     "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@1.2.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-ajR6PwQQwsQN96OH3OwO0SH5h3TGY3lLPM5lIYNUCpUXrOZ9MYJtsXvDcDKz8U/heWe0FBJeRY0nsNDJV4p9Vw=="],
 
-    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@1.11.0", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-TNtU5Wi7cEfKhnNoF6rPBJeC1FC1JBpF4S5wlGex5Wc44mnWE6bdEfqlxw7l3IxjHP5z7ppxx/WRal+FWN40CA=="],
+    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@1.11.1", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-m8bioReoQzzm7uj3sxXLH7Haclyj1UWnPCSxy2QXvGQ2yp24H1GnzqohVnXo3JfBpJzmCUAaHT+lAhYu9Gh6Aw=="],
 
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.57.0", "", { "os": "android", "cpu": "arm" }, "sha512-qVBsEO+KugOsCmUHcO8iqNnqc65p7PCKpCs8M66mPZ+Ri+CWbcpoQOEJBg2OTu03+0qu++NK1jj6IzvQVs0Sig=="],
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@flowscripter/dynamic-cli-framework-api": "^1.2.0",
-    "@flowscripter/dynamic-plugin-framework": "1.11.0",
+    "@flowscripter/dynamic-plugin-framework": "1.11.1",
     "emphasize": "^7.0.0",
     "fastest-levenshtein": "^1.0.16",
     "figlet": "^1.11.0",

--- a/src/service/spawn/DefaultSpawnService.ts
+++ b/src/service/spawn/DefaultSpawnService.ts
@@ -1,3 +1,4 @@
+import process from "node:process";
 import type {
   PrinterService,
   ShutdownService,
@@ -10,6 +11,26 @@ import getLogger from "../../util/logger.ts";
 const logger = getLogger("DefaultSpawnService");
 
 const SHUTDOWN_GRACE_PERIOD_MS = 5000;
+
+/**
+ * On Windows, batch-file shims (e.g. `npm.cmd`, `bun.cmd`) cannot be launched directly via
+ * `CreateProcess` - they must be run through `cmd.exe /c`. Resolve the command through the shell
+ * in that case; leave it untouched on other platforms.
+ */
+export function resolveForPlatform(command: ReadonlyArray<string>): string[] {
+  if (process.platform !== "win32") {
+    return [...command];
+  }
+  const [bin, ...args] = command;
+  if (bin === undefined) {
+    return [...command];
+  }
+  const resolved = Bun.which(bin) ?? bin;
+  if (!/\.(cmd|bat)$/i.test(resolved)) {
+    return [resolved, ...args];
+  }
+  return ["cmd.exe", "/d", "/s", "/c", resolved, ...args];
+}
 
 export default class DefaultSpawnService implements SpawnService {
   #printerService: PrinterService | undefined;
@@ -68,7 +89,7 @@ export default class DefaultSpawnService implements SpawnService {
 
     let proc;
     try {
-      proc = Bun.spawn([...command], {
+      proc = Bun.spawn(resolveForPlatform(command), {
         cwd: options.cwd,
         stdin: stdio === "wrapped" ? "ignore" : "inherit",
         stdout: stdio === "wrapped" ? "pipe" : "inherit",

--- a/tests/service/spawn/DefaultSpawnService.test.ts
+++ b/tests/service/spawn/DefaultSpawnService.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, test } from "bun:test";
-import DefaultSpawnService from "../../../src/service/spawn/DefaultSpawnService.ts";
+import process from "node:process";
+import { afterEach, describe, expect, test } from "bun:test";
+import DefaultSpawnService, {
+  resolveForPlatform,
+} from "../../../src/service/spawn/DefaultSpawnService.ts";
 import type { PrinterService, ShutdownService } from "@flowscripter/dynamic-cli-framework-api";
 
 interface FakePrinterServiceState {
@@ -162,5 +165,54 @@ describe("DefaultSpawnService tests", () => {
     await service.spawn(["echo", "hello"]);
 
     expect(state.listeners.length).toEqual(1);
+  });
+});
+
+describe("resolveForPlatform tests", () => {
+  const originalPlatform = process.platform;
+  const originalWhich = Bun.which;
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+    Bun.which = originalWhich;
+  });
+
+  test("leaves command untouched on non-win32 platforms", () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+
+    expect(resolveForPlatform(["npm", "install", "foo"])).toEqual(["npm", "install", "foo"]);
+  });
+
+  test("wraps a resolved .cmd shim through cmd.exe on win32", () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    Bun.which = (bin: string) => (bin === "npm" ? "C:\\Program Files\\nodejs\\npm.CMD" : null);
+
+    expect(resolveForPlatform(["npm", "install", "foo"])).toEqual([
+      "cmd.exe",
+      "/d",
+      "/s",
+      "/c",
+      "C:\\Program Files\\nodejs\\npm.CMD",
+      "install",
+      "foo",
+    ]);
+  });
+
+  test("does not wrap a resolved non-shim executable on win32", () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    Bun.which = (bin: string) => (bin === "bun" ? "C:\\Users\\me\\.bun\\bin\\bun.exe" : null);
+
+    expect(resolveForPlatform(["bun", "add", "foo"])).toEqual([
+      "C:\\Users\\me\\.bun\\bin\\bun.exe",
+      "add",
+      "foo",
+    ]);
+  });
+
+  test("falls back to the bare binary name on win32 if Bun.which cannot resolve it", () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    Bun.which = () => null;
+
+    expect(resolveForPlatform(["npm", "install", "foo"])).toEqual(["npm", "install", "foo"]);
   });
 });


### PR DESCRIPTION
## Summary
- `DefaultSpawnService.spawn()` passed the bare `npm`/`bun` command straight to `Bun.spawn`, with no shell resolution. On Windows these resolve to `.cmd` shims, which Win32's `CreateProcess` cannot execute directly, causing the spawned process to hang until the caller's own timeout kills it.
- Added `resolveForPlatform()`: on `win32`, resolves the binary via `Bun.which` and, if it's a `.cmd`/`.bat` shim, wraps the invocation through `cmd.exe /d /s /c`. No-op on other platforms.

## Context
Found while investigating a Windows-only functional test failure in `example-cli`'s CI (`plugin:add` scenario timing out after 30s): https://github.com/flowscripter/example-cli/actions/runs/29579811637/job/87890680929

This is the `SpawnInterface` implementation that `dynamic-plugin-framework`'s `NpmPluginManager` uses to shell out to npm/bun for plugin installs, so the hang there traces back to this spawn call.

A matching fix is also going into `dynamic-plugin-framework`'s own `Bun.spawn` fallback (used when no `SpawnInterface` is injected).

## Test plan
- [x] `bunx tsc --noEmit -p tsconfig.build.json` - clean
- [x] `bunx oxlint` on changed files - clean
- [x] `bun test` - full suite passes (739/739)
- [x] Added unit tests for `resolveForPlatform()` covering: non-win32 passthrough, `.cmd` shim wrapping, non-shim executable passthrough on win32, and `Bun.which` miss fallback

https://claude.ai/code/session_01BHouCzjk6bFtxnHDPmiocC