### PR TITLE
feat: add real timeout/abort support to DefaultSpawnService and cache upgrade checks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@flowscripter/dynamic-cli-framework",
       "dependencies": {
-        "@flowscripter/dynamic-cli-framework-api": "^1.2.0",
+        "@flowscripter/dynamic-cli-framework-api": "^1.3.0",
         "@flowscripter/dynamic-plugin-framework": "1.11.1",
         "emphasize": "^7.0.0",
         "fastest-levenshtein": "^1.0.16",
@@ -29,7 +29,7 @@
     },
   },
   "packages": {
-    "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@1.2.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-ajR6PwQQwsQN96OH3OwO0SH5h3TGY3lLPM5lIYNUCpUXrOZ9MYJtsXvDcDKz8U/heWe0FBJeRY0nsNDJV4p9Vw=="],
+    "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@1.3.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-/Rn4r5ZteMr8Zc5bDu9mM7MgGe0VUAvg2TSmzaZXkMqiFzYkMeGB+WzIcqMpDh9TAd4kdLHVHd3wjfmPjUw1eA=="],
 
     "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@1.11.1", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-m8bioReoQzzm7uj3sxXLH7Haclyj1UWnPCSxy2QXvGQ2yp24H1GnzqohVnXo3JfBpJzmCUAaHT+lAhYu9Gh6Aw=="],
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "build": "tsc -p tsconfig.build.json"
   },
   "dependencies": {
-    "@flowscripter/dynamic-cli-framework-api": "^1.2.0",
+    "@flowscripter/dynamic-cli-framework-api": "^1.3.0",
     "@flowscripter/dynamic-plugin-framework": "1.11.1",
     "emphasize": "^7.0.0",
     "fastest-levenshtein": "^1.0.16",

--- a/src/command/VersionCommand.ts
+++ b/src/command/VersionCommand.ts
@@ -19,7 +19,7 @@ export default class VersionCommand implements GlobalCommand {
     let line = context.cliConfig.version;
     if (context.doesServiceExist(UPGRADE_SERVICE_ID)) {
       const upgradeService = context.getServiceById(UPGRADE_SERVICE_ID) as UpgradeService;
-      const result = await upgradeService.checkForUpgrade().catch(() => undefined);
+      const result = await upgradeService.getUpgradeCheckResult().catch(() => undefined);
       if (result?.updateAvailable) {
         line += ` (${result.latestVersion} available, run '${context.cliConfig.name} upgrade')`;
       }

--- a/src/service/banner/BannerServiceProvider.ts
+++ b/src/service/banner/BannerServiceProvider.ts
@@ -72,7 +72,7 @@ export default class BannerServiceProvider implements ServiceProvider {
     }
     if (context.doesServiceExist(UPGRADE_SERVICE_ID)) {
       const upgradeService = context.getServiceById(UPGRADE_SERVICE_ID) as UpgradeService;
-      const result = await upgradeService.checkForUpgrade().catch(() => undefined);
+      const result = await upgradeService.getUpgradeCheckResult().catch(() => undefined);
       if (result?.updateAvailable) {
         await printerService.info(
           `  ${printerService.secondary(

--- a/src/service/plugin/SpawnInterfaceAdapter.ts
+++ b/src/service/plugin/SpawnInterfaceAdapter.ts
@@ -55,8 +55,11 @@ export default class SpawnInterfaceAdapter implements SpawnInterface {
     this.#printerService.endMark();
     await this.#printerService.clearMarked(this.#markMinimumDisplayTimeMs);
 
-    return result.ok
-      ? { ok: true, exitCode: result.exitCode }
+    if (result.ok) {
+      return { ok: true, exitCode: result.exitCode };
+    }
+    return "timedOut" in result
+      ? { ok: false, error: new Error("Command timed out") }
       : { ok: false, exitCode: result.exitCode, error: result.error };
   }
 }

--- a/src/service/spawn/DefaultSpawnService.ts
+++ b/src/service/spawn/DefaultSpawnService.ts
@@ -41,6 +41,22 @@ export default class DefaultSpawnService implements SpawnService {
     this.#shutdownService = shutdownService;
   }
 
+  async #terminate(
+    proc: ReturnType<typeof Bun.spawn>,
+    command: ReadonlyArray<string>,
+  ): Promise<void> {
+    logger.debug(() => `Sending SIGTERM to spawned command '${command.join(" ")}'`);
+    proc.kill("SIGTERM");
+    const exitedInTime = await Promise.race([
+      proc.exited.then(() => true),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), SHUTDOWN_GRACE_PERIOD_MS)),
+    ]);
+    if (!exitedInTime) {
+      logger.debug(() => `Sending SIGKILL to spawned command '${command.join(" ")}'`);
+      proc.kill("SIGKILL");
+    }
+  }
+
   async #pipeLines(
     stream: ReadableStream<Uint8Array> | number | undefined,
     streamName: "stdout" | "stderr",
@@ -110,16 +126,7 @@ export default class DefaultSpawnService implements SpawnService {
       if (settled) {
         return;
       }
-      logger.debug(() => `Sending SIGTERM to spawned command '${command.join(" ")}'`);
-      proc.kill("SIGTERM");
-      await Promise.race([
-        proc.exited.then(() => {}),
-        new Promise<void>((resolve) => setTimeout(resolve, SHUTDOWN_GRACE_PERIOD_MS)),
-      ]);
-      if (!settled) {
-        logger.debug(() => `Sending SIGKILL to spawned command '${command.join(" ")}'`);
-        proc.kill("SIGKILL");
-      }
+      await this.#terminate(proc, command);
     });
 
     if (stdio === "wrapped" && options.onOutput) {
@@ -129,6 +136,28 @@ export default class DefaultSpawnService implements SpawnService {
     }
 
     try {
+      if (options.timeoutMs === undefined) {
+        const exitCode = await proc.exited;
+        settled = true;
+        return exitCode === 0 ? { ok: true, exitCode } : { ok: false, exitCode };
+      }
+
+      let timeoutHandle: ReturnType<typeof setTimeout>;
+      const timedOut = await Promise.race([
+        proc.exited.then(() => false),
+        new Promise<boolean>((resolve) => {
+          timeoutHandle = setTimeout(() => resolve(true), options.timeoutMs);
+        }),
+      ]);
+      clearTimeout(timeoutHandle!);
+
+      if (timedOut) {
+        logger.debug(() => `Command '${command.join(" ")}' timed out after ${options.timeoutMs}ms`);
+        await this.#terminate(proc, command);
+        settled = true;
+        return { ok: false, timedOut: true };
+      }
+
       const exitCode = await proc.exited;
       settled = true;
       return exitCode === 0 ? { ok: true, exitCode } : { ok: false, exitCode };

--- a/src/service/upgrade/DefaultUpgradeService.ts
+++ b/src/service/upgrade/DefaultUpgradeService.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import type {
   CLIConfig,
   ShutdownService,
+  SpawnResult,
   SpawnService,
   UpgradeCheckResult,
   UpgradeResult,
@@ -22,18 +23,13 @@ import getLogger from "../../util/logger.ts";
 const logger = getLogger("DefaultUpgradeService");
 
 // checkForUpgrade() runs opportunistically on every CLI invocation (via BannerServiceProvider),
-// so its version-check network calls must never be allowed to stall CLI startup.
-const VERSION_CHECK_TIMEOUT_MS = 250;
+// so its version-check network/spawn calls must never be allowed to stall CLI startup.
+export const VERSION_CHECK_TIMEOUT_MS = 250;
 
-// SpawnService has no built-in cancellation, so a stalled `brew`/`winget` invocation (e.g. winget's
-// first-ever run on a machine prompting to accept Microsoft Store terms) can otherwise hang
-// checkForUpgrade() indefinitely. Racing against this bounds how long we wait for a result; the
-// underlying process is not killed, but the CLI stops blocking on it.
-async function withSpawnTimeout<T>(spawnPromise: Promise<T>, fallback: T): Promise<T> {
-  return Promise.race([
-    spawnPromise,
-    new Promise<T>((resolve) => setTimeout(() => resolve(fallback), VERSION_CHECK_TIMEOUT_MS)),
-  ]);
+function describeSpawnFailure(result: Extract<SpawnResult, { ok: false }>): string {
+  return "timedOut" in result
+    ? "timed out"
+    : (result.error?.message ?? `exit code ${result.exitCode}`);
 }
 
 const OS_LABELS: Record<SupportedOs, string> = {
@@ -45,6 +41,7 @@ const OS_LABELS: Record<SupportedOs, string> = {
 export default class DefaultUpgradeService implements UpgradeService {
   #spawnService: SpawnService | undefined;
   #shutdownService: ShutdownService | undefined;
+  #upgradeCheckPromise: Promise<UpgradeCheckResult | undefined> | undefined;
   readonly #config: UpgradeLocationsConfig;
   readonly #cliConfig: CLIConfig;
 
@@ -56,6 +53,21 @@ export default class DefaultUpgradeService implements UpgradeService {
   public setDependencies(spawnService: SpawnService, shutdownService?: ShutdownService): void {
     this.#spawnService = spawnService;
     this.#shutdownService = shutdownService;
+  }
+
+  public getUpgradeCheckResult(waitForResult = false): Promise<UpgradeCheckResult | undefined> {
+    if (!this.#upgradeCheckPromise) {
+      this.#upgradeCheckPromise = this.checkForUpgrade();
+    }
+    if (waitForResult) {
+      return this.#upgradeCheckPromise;
+    }
+    return Promise.race([
+      this.#upgradeCheckPromise,
+      new Promise<undefined>((resolve) =>
+        setTimeout(() => resolve(undefined), VERSION_CHECK_TIMEOUT_MS),
+      ),
+    ]);
   }
 
   public detectOs(): SupportedOs | undefined {
@@ -143,7 +155,11 @@ export default class DefaultUpgradeService implements UpgradeService {
     installMethodOverride?: InstallMethod,
   ): Promise<UpgradeResult> {
     const oldVersion = this.#cliConfig.version;
-    const checkResult = await this.checkForUpgrade(osOverride, archOverride, installMethodOverride);
+    const hasOverride =
+      osOverride !== undefined || archOverride !== undefined || installMethodOverride !== undefined;
+    const checkResult = hasOverride
+      ? await this.checkForUpgrade(osOverride, archOverride, installMethodOverride)
+      : await this.getUpgradeCheckResult(true);
     if (!checkResult) {
       return {
         ok: false,
@@ -186,12 +202,9 @@ export default class DefaultUpgradeService implements UpgradeService {
     if (!this.#spawnService || !this.#config.homebrew) {
       return false;
     }
-    const result = await withSpawnTimeout(
-      this.#spawnService.spawn(["brew", "list", "--versions", this.#config.homebrew.formula], {
-        stdio: "wrapped",
-        longRunning: false,
-      }),
-      { ok: false } as const,
+    const result = await this.#spawnService.spawn(
+      ["brew", "list", "--versions", this.#config.homebrew.formula],
+      { stdio: "wrapped", longRunning: false, timeoutMs: VERSION_CHECK_TIMEOUT_MS },
     );
     return result.ok;
   }
@@ -200,12 +213,9 @@ export default class DefaultUpgradeService implements UpgradeService {
     if (!this.#spawnService || !this.#config.winget) {
       return false;
     }
-    const result = await withSpawnTimeout(
-      this.#spawnService.spawn(["winget", "list", "--id", this.#config.winget.packageId], {
-        stdio: "wrapped",
-        longRunning: false,
-      }),
-      { ok: false } as const,
+    const result = await this.#spawnService.spawn(
+      ["winget", "list", "--id", this.#config.winget.packageId],
+      { stdio: "wrapped", longRunning: false, timeoutMs: VERSION_CHECK_TIMEOUT_MS },
     );
     return result.ok;
   }
@@ -279,13 +289,14 @@ export default class DefaultUpgradeService implements UpgradeService {
       return undefined;
     }
     const lines: string[] = [];
-    const result = await withSpawnTimeout(
-      this.#spawnService.spawn(["winget", "show", "--id", this.#config.winget.packageId], {
+    const result = await this.#spawnService.spawn(
+      ["winget", "show", "--id", this.#config.winget.packageId],
+      {
         stdio: "wrapped",
         longRunning: false,
+        timeoutMs: VERSION_CHECK_TIMEOUT_MS,
         onOutput: (line) => lines.push(line),
-      }),
-      { ok: false } as const,
+      },
     );
     if (!result.ok) {
       return undefined;
@@ -303,9 +314,7 @@ export default class DefaultUpgradeService implements UpgradeService {
     const { scriptUrl } = this.#config.linuxScript!;
     const result = await this.#spawnService!.spawn(["sh", "-c", `curl -fsSL ${scriptUrl} | sh`]);
     if (!result.ok) {
-      throw new Error(
-        `Install script failed: ${result.error?.message ?? `exit code ${result.exitCode}`}`,
-      );
+      throw new Error(`Install script failed: ${describeSpawnFailure(result)}`);
     }
   }
 
@@ -313,9 +322,7 @@ export default class DefaultUpgradeService implements UpgradeService {
     const { tap, formula } = this.#config.homebrew!;
     const result = await this.#spawnService!.spawn(["brew", "upgrade", `${tap}/${formula}`]);
     if (!result.ok) {
-      throw new Error(
-        `brew upgrade failed: ${result.error?.message ?? `exit code ${result.exitCode}`}`,
-      );
+      throw new Error(`brew upgrade failed: ${describeSpawnFailure(result)}`);
     }
   }
 
@@ -331,9 +338,7 @@ export default class DefaultUpgradeService implements UpgradeService {
       "--accept-source-agreements",
     ]);
     if (!result.ok) {
-      throw new Error(
-        `winget upgrade failed: ${result.error?.message ?? `exit code ${result.exitCode}`}`,
-      );
+      throw new Error(`winget upgrade failed: ${describeSpawnFailure(result)}`);
     }
   }
 
@@ -344,8 +349,7 @@ export default class DefaultUpgradeService implements UpgradeService {
     const assetName = assetPattern.replace("{os}", OS_LABELS[os]).replace("{arch}", archLabel);
     const url = `https://github.com/${owner}/${repo}/releases/latest/download/${assetName}`;
 
-    // Downloading the release asset happens outside SpawnService (which enters long-running mode
-    // for its own subprocesses by default), so bracket it here to get the same cooperative
+    // Downloading the release asset but enter long-running mode to get cooperative
     // Ctrl-C handling during what can be the slowest step of the upgrade.
     this.#shutdownService?.enterLongRunningMode();
     let archiveData: ArrayBuffer;

--- a/src/service/upgrade/UpgradeServiceProvider.ts
+++ b/src/service/upgrade/UpgradeServiceProvider.ts
@@ -54,6 +54,8 @@ export default class UpgradeServiceProvider implements ServiceProvider {
       logger.debug(() => "SpawnService not available, upgrade install methods will be unavailable");
     }
 
+    void upgradeService.getUpgradeCheckResult();
+
     if (!context.doesServiceExist(PROMPTER_SERVICE_ID)) {
       logger.debug(() => "PrompterService not available, skipping auto-upgrade");
       return;
@@ -128,7 +130,7 @@ export default class UpgradeServiceProvider implements ServiceProvider {
     cliConfig: CLIConfig,
   ): Promise<void> {
     try {
-      const checkResult = await upgradeService.checkForUpgrade();
+      const checkResult = await upgradeService.getUpgradeCheckResult();
       if (!checkResult?.updateAvailable) {
         return;
       }

--- a/src/service/upgrade/command/UpgradeSubCommand.ts
+++ b/src/service/upgrade/command/UpgradeSubCommand.ts
@@ -52,7 +52,10 @@ export class UpgradeSubCommand implements SubCommand {
     const arch = undefined as SupportedArch | undefined;
     const installMethod = argumentValues["install-method"] as InstallMethod | undefined;
 
-    const checkResult = await this.#upgradeService.checkForUpgrade(os, arch, installMethod);
+    const checkResult =
+      os === undefined && installMethod === undefined
+        ? await this.#upgradeService.getUpgradeCheckResult(true)
+        : await this.#upgradeService.checkForUpgrade(os, arch, installMethod);
     if (!checkResult) {
       await printerService.error(
         `No upgrade location is configured for the detected or requested platform.\n`,

--- a/tests/command/VersionCommand.test.ts
+++ b/tests/command/VersionCommand.test.ts
@@ -53,7 +53,7 @@ describe("VersionCommand tests", () => {
 
     context.addServiceInstance(PRINTER_SERVICE_ID, printer);
     context.addServiceInstance(UPGRADE_SERVICE_ID, {
-      checkForUpgrade: () =>
+      getUpgradeCheckResult: () =>
         Promise.resolve({
           currentVersion: "foobar",
           latestVersion: "9.9.9",
@@ -86,7 +86,7 @@ describe("VersionCommand tests", () => {
 
     context.addServiceInstance(PRINTER_SERVICE_ID, printer);
     context.addServiceInstance(UPGRADE_SERVICE_ID, {
-      checkForUpgrade: () => Promise.resolve({ updateAvailable: false }),
+      getUpgradeCheckResult: () => Promise.resolve({ updateAvailable: false }),
     });
 
     const versionCommand = new VersionCommand();

--- a/tests/service/banner/BannerServiceProvider.test.ts
+++ b/tests/service/banner/BannerServiceProvider.test.ts
@@ -106,7 +106,7 @@ describe("BannerServiceProvider tests", () => {
     context.addServiceInstance(PRINTER_SERVICE_ID, printer);
     context.addServiceInstance(ASCII_BANNER_GENERATOR_SERVICE_ID, asciiBannerGenerator);
     context.addServiceInstance(UPGRADE_SERVICE_ID, {
-      checkForUpgrade: () =>
+      getUpgradeCheckResult: () =>
         Promise.resolve({
           currentVersion: "foobar",
           latestVersion: "9.9.9",

--- a/tests/service/spawn/DefaultSpawnService.test.ts
+++ b/tests/service/spawn/DefaultSpawnService.test.ts
@@ -166,6 +166,32 @@ describe("DefaultSpawnService tests", () => {
 
     expect(state.listeners.length).toEqual(1);
   });
+
+  test("spawn() resolves ok:true within timeoutMs if the process exits in time", async () => {
+    const service = new DefaultSpawnService();
+    const { printerService } = getFakePrinterService();
+    const { shutdownService } = getFakeShutdownService();
+    service.setDependencies(printerService, shutdownService);
+
+    const result = await service.spawn(["echo", "hello"], { timeoutMs: 5000 });
+
+    expect(result).toEqual({ ok: true, exitCode: 0 });
+  });
+
+  test("spawn() kills the process and resolves ok:false timedOut:true if it exceeds timeoutMs", async () => {
+    const service = new DefaultSpawnService();
+    const { printerService } = getFakePrinterService();
+    const { shutdownService } = getFakeShutdownService();
+    service.setDependencies(printerService, shutdownService);
+
+    const result = await service.spawn(["sh", "-c", "sleep 30"], {
+      stdio: "wrapped",
+      longRunning: false,
+      timeoutMs: 100,
+    });
+
+    expect(result).toEqual({ ok: false, timedOut: true });
+  });
 });
 
 describe("resolveForPlatform tests", () => {

--- a/tests/service/upgrade/DefaultUpgradeService.test.ts
+++ b/tests/service/upgrade/DefaultUpgradeService.test.ts
@@ -3,7 +3,9 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { InstallMethod, SupportedArch, SupportedOs } from "@flowscripter/dynamic-cli-framework-api";
 import type { SpawnResult, SpawnService } from "@flowscripter/dynamic-cli-framework-api";
 import type { CLIConfig } from "@flowscripter/dynamic-cli-framework-api";
-import DefaultUpgradeService from "../../../src/service/upgrade/DefaultUpgradeService.ts";
+import DefaultUpgradeService, {
+  VERSION_CHECK_TIMEOUT_MS,
+} from "../../../src/service/upgrade/DefaultUpgradeService.ts";
 import type { UpgradeLocationsConfig } from "../../../src/service/upgrade/UpgradeLocationsConfig.ts";
 import { getCLIConfig as getFixtureCLIConfig } from "../../fixtures/CLIConfig.ts";
 
@@ -91,7 +93,7 @@ describe("DefaultUpgradeService", () => {
     expect(await service.detectInstallMethod(SupportedOs.MACOS)).toEqual(InstallMethod.HOMEBREW);
   });
 
-  test("detectInstallMethod falls through to GITHUB_RELEASE if a stalled winget check never resolves", async () => {
+  test("detectInstallMethod falls through to GITHUB_RELEASE if the winget check times out", async () => {
     const service = new DefaultUpgradeService(
       getConfig({
         winget: { packageId: "Flowscripter.example-cli" },
@@ -99,7 +101,14 @@ describe("DefaultUpgradeService", () => {
       }),
       getCLIConfig(),
     );
-    service.setDependencies({ spawn: () => new Promise(() => {}) });
+    service.setDependencies({
+      // Mimics DefaultSpawnService's real timeoutMs handling: a stalled process resolves
+      // { ok: false, timedOut: true } once the caller-specified timeoutMs elapses.
+      spawn: (_command, options) =>
+        options?.timeoutMs === undefined
+          ? new Promise(() => {})
+          : Promise.resolve({ ok: false, timedOut: true }),
+    });
     expect(await service.detectInstallMethod(SupportedOs.WINDOWS)).toEqual(
       InstallMethod.GITHUB_RELEASE,
     );
@@ -297,5 +306,91 @@ describe("DefaultUpgradeService", () => {
     );
     expect(result.ok).toBe(false);
     expect(result.error?.message).toContain("brew upgrade failed");
+  });
+
+  test("getUpgradeCheckResult caches the same promise across calls", async () => {
+    let checkCount = 0;
+    globalThis.fetch = (() => {
+      checkCount++;
+      return Promise.resolve(new Response(JSON.stringify({ tag_name: "v9.9.9" }), { status: 200 }));
+    }) as unknown as typeof fetch;
+
+    const service = new DefaultUpgradeService(
+      getConfig({
+        githubRelease: { owner: "flowscripter", repo: "example-cli", assetPattern: "x" },
+      }),
+      getCLIConfig(),
+    );
+
+    const first = service.getUpgradeCheckResult(true);
+    const second = service.getUpgradeCheckResult(true);
+    expect(first).toBe(second);
+    await first;
+    await second;
+    expect(checkCount).toEqual(1);
+  });
+
+  test("getUpgradeCheckResult resolves undefined if the cached check exceeds VERSION_CHECK_TIMEOUT_MS", async () => {
+    const service = new DefaultUpgradeService(
+      getConfig({
+        githubRelease: { owner: "flowscripter", repo: "example-cli", assetPattern: "x" },
+      }),
+      getCLIConfig(),
+    );
+    globalThis.fetch = (() => new Promise(() => {})) as unknown as typeof fetch;
+
+    const result = await service.getUpgradeCheckResult();
+    expect(result).toBeUndefined();
+  });
+
+  test("getUpgradeCheckResult(true) waits for the full result with no timeout", async () => {
+    const service = new DefaultUpgradeService(
+      getConfig({
+        githubRelease: { owner: "flowscripter", repo: "example-cli", assetPattern: "x" },
+      }),
+      getCLIConfig(),
+    );
+    globalThis.fetch = (() =>
+      new Promise((resolve) =>
+        setTimeout(
+          () => resolve(new Response(JSON.stringify({ tag_name: "v9.9.9" }), { status: 200 })),
+          VERSION_CHECK_TIMEOUT_MS + 50,
+        ),
+      )) as unknown as typeof fetch;
+
+    const result = await service.getUpgradeCheckResult(true);
+    expect(result?.latestVersion).toEqual("9.9.9");
+  });
+
+  test("upgrade bypasses the cached check when an override is passed", async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response('version "v9.9.9"', { status: 200 }),
+      )) as unknown as typeof fetch;
+
+    const spawnedCommands: ReadonlyArray<string>[] = [];
+    const service = new DefaultUpgradeService(
+      getConfig({ homebrew: { tap: "flowscripter/tap", formula: "example-cli" } }),
+      getCLIConfig(),
+    );
+    service.setDependencies(
+      getSpawnService((command) => {
+        spawnedCommands.push(command);
+        return { ok: true, exitCode: 0 };
+      }),
+    );
+
+    // Prime the cache with default (no-override) detection, which resolves undefined since
+    // supportedPlatforms only covers LINUX/MACOS/WINDOWS x specific arches and detectOs()/
+    // detectArch() here reflect the actual test host - the override call below must not reuse it.
+    void service.getUpgradeCheckResult();
+
+    const result = await service.upgrade(
+      SupportedOs.MACOS,
+      SupportedArch.ARM64,
+      InstallMethod.HOMEBREW,
+    );
+    expect(result.ok).toBe(true);
+    expect(result.newVersion).toEqual("9.9.9");
   });
 });

--- a/tests/service/upgrade/command/UpgradeSubCommand.test.ts
+++ b/tests/service/upgrade/command/UpgradeSubCommand.test.ts
@@ -17,6 +17,7 @@ function getUpgradeService(
 ): DefaultUpgradeService {
   return {
     checkForUpgrade: () => Promise.resolve(checkResult),
+    getUpgradeCheckResult: () => Promise.resolve(checkResult),
     upgrade: () => Promise.resolve(upgradeResult!),
   } as unknown as DefaultUpgradeService;
 }


### PR DESCRIPTION
## Summary
- Bumps `@flowscripter/dynamic-cli-framework-api` to `^1.3.0` for `SpawnOptions.timeoutMs`, `SpawnResult`'s new `timedOut` state, and `UpgradeService.getUpgradeCheckResult()` (flowscripter/dynamic-cli-framework-api#5).
- `DefaultSpawnService.spawn` now honors an optional `timeoutMs`, killing the spawned process (`SIGTERM` then `SIGKILL`) if it doesn't exit in time, sharing the same terminate logic as the existing shutdown-listener path.
- `DefaultUpgradeService` now starts its version check eagerly once dependencies are wired in `UpgradeServiceProvider.initService`, caches the resulting promise, and exposes it via `getUpgradeCheckResult()` with a bounded (default, `VERSION_CHECK_TIMEOUT_MS`) or unbounded wait. This replaces the private, non-cancelling `withSpawnTimeout` helper, which only stopped the *caller* from waiting without actually killing a stalled `brew`/`winget` process.
- `VersionCommand`, `BannerServiceProvider`, and `UpgradeServiceProvider#checkAndUpgrade` now use the cached, bounded check; `DefaultUpgradeService.upgrade()` and `UpgradeSubCommand.execute()` wait for the full (unbounded) result unless an `os`/`install-method` override is supplied, in which case they bypass the cache and check fresh.

## Test plan
- [x] `bun run build` (tsc) passes
- [x] `bun test` - 747/747 pass, including new timeout tests for `DefaultSpawnService` and cache/bypass tests for `DefaultUpgradeService`
- [x] `deno lint` shows only pre-existing, unrelated issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)