### PR TITLE
feat: add FetchService, rename SpawnOptions.stdio to mode, convert upgrade to use both

### DIFF
--- a/README/core-service-providers.md
+++ b/README/core-service-providers.md
@@ -91,6 +91,21 @@ Provides:
   between groups, and byte-range-based color schemes for visual differentiation
   of byte value ranges.
 
+## `FetchServiceProvider`
+
+Provides:
+
+- `FetchService` allowing a `Command` to perform a `fetch()` request. Supports the same options as
+  native `fetch()` (method, headers, body, etc. via `RequestInit`) plus an optional `timeoutMs` and
+  cooperation with `ShutdownService`'s long-running mode (`longRunning: true`) so a single Ctrl-C
+  gracefully aborts the request rather than immediately exiting the CLI. A timeout rejects with a
+  `DOMException` named `"TimeoutError"`, a shutdown-triggered abort rejects with one named
+  `"AbortError"`, and a genuine network failure rejects with a `TypeError` - the same distinction
+  native `fetch()` already gives.
+
+NOTE: This service is opt-in. Enable via `fetchServiceEnabled` flag on `BaseCLI`,
+`DefaultRuntimeCLI`, or the launcher functions.
+
 ## `ImagePrinterServiceProvider`
 
 Provides:
@@ -173,12 +188,13 @@ shutdownService.leaveLongRunningMode();
 Provides:
 
 - `SpawnService` allowing a `Command` to spawn a child process. Output can
-  optionally be captured line-by-line via a callback (`stdio: "wrapped"`)
-  instead of being inherited directly by the CLI's stdout/stderr, and shutdown
-  signals are gracefully forwarded to the spawned process (SIGTERM, followed by
-  SIGKILL after a grace period if it hasn't exited). Cooperates with
-  `ShutdownService`'s long-running mode so a single Ctrl-C terminates the
-  spawned process rather than immediately exiting the CLI.
+  optionally be captured line-by-line via a callback (`mode: "wrapped"`)
+  instead of being inherited directly by the CLI's stdout/stderr, or discarded
+  entirely (`mode: "ignore"`). Shutdown signals are gracefully forwarded to the
+  spawned process (SIGTERM, followed by SIGKILL after a grace period if it
+  hasn't exited). Cooperates with `ShutdownService`'s long-running mode so a
+  single Ctrl-C terminates the spawned process rather than immediately exiting
+  the CLI.
 
 NOTE: This service is opt-in. Enable via `spawnServiceEnabled` flag on
 `BaseCLI`, `DefaultRuntimeCLI`, or the launcher functions.
@@ -240,7 +256,9 @@ Provides:
 
 NOTE: This service is opt-in. Enable via `upgradeServiceEnabled` flag (with
 `upgradeLocationsConfig` supplying the release locations) on `BaseCLI`,
-`DefaultRuntimeCLI`, or the launcher functions. Requires `SpawnServiceProvider`
-(`spawnServiceEnabled`) to also be enabled for the install/upgrade step itself
-to work; without it, upgrade availability can still be detected and reported
+`DefaultRuntimeCLI`, or the launcher functions. Requires `FetchServiceProvider`
+(`fetchServiceEnabled`) for the version-check/download fetches, and
+`SpawnServiceProvider` (`spawnServiceEnabled`) for the install/upgrade step
+itself and for the Homebrew/Winget detection and version-check spawns; without
+either, upgrade availability can still be partially detected and reported
 (e.g. by `VersionCommand`) but not installed.

--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "@flowscripter/dynamic-cli-framework",
       "dependencies": {
-        "@flowscripter/dynamic-cli-framework-api": "^1.3.0",
-        "@flowscripter/dynamic-plugin-framework": "1.11.1",
+        "@flowscripter/dynamic-cli-framework-api": "^1.4.0",
+        "@flowscripter/dynamic-plugin-framework": "1.12.0",
         "emphasize": "^7.0.0",
         "fastest-levenshtein": "^1.0.16",
         "figlet": "^1.11.0",
@@ -29,9 +29,9 @@
     },
   },
   "packages": {
-    "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@1.3.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-/Rn4r5ZteMr8Zc5bDu9mM7MgGe0VUAvg2TSmzaZXkMqiFzYkMeGB+WzIcqMpDh9TAd4kdLHVHd3wjfmPjUw1eA=="],
+    "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@1.4.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-RTBaqMaxfcV2Rp/Yz5c1RdHbpFq7sCX7dh6AVBw5HYQg3h17AtffaZa8yB7urrFY4CsuZ9DMPA5+utBklzVAlw=="],
 
-    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@1.11.1", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-m8bioReoQzzm7uj3sxXLH7Haclyj1UWnPCSxy2QXvGQ2yp24H1GnzqohVnXo3JfBpJzmCUAaHT+lAhYu9Gh6Aw=="],
+    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@1.12.0", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-wdwDTpwp34K4Eh0YwClb3OQMUUt5M6v9cgr5ugQ+uJi68cc2YtDiX7kyrPBZsjw8SSrpmLkgJ91jXJ/f61jqVQ=="],
 
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.57.0", "", { "os": "android", "cpu": "arm" }, "sha512-qVBsEO+KugOsCmUHcO8iqNnqc65p7PCKpCs8M66mPZ+Ri+CWbcpoQOEJBg2OTu03+0qu++NK1jj6IzvQVs0Sig=="],
 

--- a/index.ts
+++ b/index.ts
@@ -78,6 +78,11 @@ export type { ShutdownService } from "@flowscripter/dynamic-cli-framework-api";
 export { default as DefaultShutdownService } from "./src/service/shutdown/DefaultShutdownService.ts";
 export { default as ShutdownServiceProvider } from "./src/service/shutdown/ShutdownServiceProvider.ts";
 
+export { FETCH_SERVICE_ID } from "@flowscripter/dynamic-cli-framework-api";
+export type { FetchOptions, FetchService } from "@flowscripter/dynamic-cli-framework-api";
+export { default as DefaultFetchService } from "./src/service/fetch/DefaultFetchService.ts";
+export { default as FetchServiceProvider } from "./src/service/fetch/FetchServiceProvider.ts";
+
 export { SPAWN_SERVICE_ID } from "@flowscripter/dynamic-cli-framework-api";
 export type {
   SpawnOptions,

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "build": "tsc -p tsconfig.build.json"
   },
   "dependencies": {
-    "@flowscripter/dynamic-cli-framework-api": "^1.3.0",
-    "@flowscripter/dynamic-plugin-framework": "1.11.1",
+    "@flowscripter/dynamic-cli-framework-api": "^1.4.0",
+    "@flowscripter/dynamic-plugin-framework": "1.12.0",
     "emphasize": "^7.0.0",
     "fastest-levenshtein": "^1.0.16",
     "figlet": "^1.11.0",

--- a/src/cli/BaseCLI.ts
+++ b/src/cli/BaseCLI.ts
@@ -52,6 +52,7 @@ import DefaultCompletionService from "../service/completion/DefaultCompletionSer
 import CompletionServiceProvider from "../service/completion/CompletionServiceProvider.ts";
 import ImagePrinterServiceProvider from "../service/imagePrinter/ImagePrinterServiceProvider.ts";
 import SpawnServiceProvider from "../service/spawn/SpawnServiceProvider.ts";
+import FetchServiceProvider from "../service/fetch/FetchServiceProvider.ts";
 import UpgradeServiceProvider from "../service/upgrade/UpgradeServiceProvider.ts";
 const logger = getLogger("BaseCLI");
 
@@ -72,6 +73,7 @@ const logger = getLogger("BaseCLI");
  *
  * * {@link ImagePrinterServiceProvider}
  * * {@link SpawnServiceProvider}
+ * * {@link FetchServiceProvider}
  * * {@link CompletionServiceProvider}
  * * {@link UpgradeServiceProvider}
  *
@@ -136,6 +138,7 @@ export default class BaseCLI implements CLI {
       completionServiceEnabled: false,
       imagePrinterServiceEnabled: false,
       spawnServiceEnabled: false,
+      fetchServiceEnabled: false,
       upgradeServiceEnabled: false,
       upgradeLocationsConfig: { supportedPlatforms: [] },
       validateAllCommands: false,
@@ -272,6 +275,10 @@ export default class BaseCLI implements CLI {
 
     if (this.#options.spawnServiceEnabled) {
       this.addServiceProvider(new SpawnServiceProvider(58));
+    }
+
+    if (this.#options.fetchServiceEnabled) {
+      this.addServiceProvider(new FetchServiceProvider(57));
     }
 
     if (this.#options.completionServiceEnabled) {

--- a/src/cli/BaseCLIFeatureOptions.ts
+++ b/src/cli/BaseCLIFeatureOptions.ts
@@ -9,6 +9,7 @@ export default interface BaseCLIFeatureOptions {
   readonly completionServiceEnabled?: boolean;
   readonly imagePrinterServiceEnabled?: boolean;
   readonly spawnServiceEnabled?: boolean;
+  readonly fetchServiceEnabled?: boolean;
   readonly upgradeServiceEnabled?: boolean;
   readonly upgradeLocationsConfig?: UpgradeLocationsConfig;
   readonly validateAllCommands?: boolean;

--- a/src/service/fetch/DefaultFetchService.ts
+++ b/src/service/fetch/DefaultFetchService.ts
@@ -1,4 +1,8 @@
-import type { FetchOptions, FetchService, ShutdownService } from "@flowscripter/dynamic-cli-framework-api";
+import type {
+  FetchOptions,
+  FetchService,
+  ShutdownService,
+} from "@flowscripter/dynamic-cli-framework-api";
 import getLogger from "../../util/logger.ts";
 
 const logger = getLogger("DefaultFetchService");

--- a/src/service/fetch/DefaultFetchService.ts
+++ b/src/service/fetch/DefaultFetchService.ts
@@ -1,0 +1,51 @@
+import type { FetchOptions, FetchService, ShutdownService } from "@flowscripter/dynamic-cli-framework-api";
+import getLogger from "../../util/logger.ts";
+
+const logger = getLogger("DefaultFetchService");
+
+export default class DefaultFetchService implements FetchService {
+  #shutdownService: ShutdownService | undefined;
+
+  public setDependencies(shutdownService: ShutdownService): void {
+    this.#shutdownService = shutdownService;
+  }
+
+  public async fetch(input: string | URL, options: FetchOptions = {}): Promise<Response> {
+    if (this.#shutdownService === undefined) {
+      throw new Error("DefaultFetchService.fetch() called before setDependencies()");
+    }
+    const shutdownService = this.#shutdownService;
+    const { timeoutMs, longRunning = false, signal: callerSignal, ...requestInit } = options;
+
+    const controller = new AbortController();
+    const signals: AbortSignal[] = [controller.signal];
+    if (callerSignal) {
+      signals.push(callerSignal);
+    }
+    if (timeoutMs !== undefined) {
+      signals.push(AbortSignal.timeout(timeoutMs));
+    }
+    const signal = signals.length === 1 ? signals[0]! : AbortSignal.any(signals);
+
+    let settled = false;
+    if (longRunning) {
+      shutdownService.enterLongRunningMode();
+      shutdownService.addShutdownListener(async () => {
+        if (settled) {
+          return;
+        }
+        logger.debug(() => `Aborting fetch of '${input.toString()}' due to shutdown`);
+        controller.abort();
+      });
+    }
+
+    try {
+      return await fetch(input, { ...requestInit, signal });
+    } finally {
+      settled = true;
+      if (longRunning) {
+        shutdownService.leaveLongRunningMode();
+      }
+    }
+  }
+}

--- a/src/service/fetch/FetchServiceProvider.ts
+++ b/src/service/fetch/FetchServiceProvider.ts
@@ -1,0 +1,27 @@
+import type { CLIConfig, Context, ServiceInfo, ServiceProvider, ShutdownService } from "@flowscripter/dynamic-cli-framework-api";
+import { FETCH_SERVICE_ID, SHUTDOWN_SERVICE_ID } from "@flowscripter/dynamic-cli-framework-api";
+import DefaultFetchService from "./DefaultFetchService.ts";
+
+export default class FetchServiceProvider implements ServiceProvider {
+  readonly serviceId: string = FETCH_SERVICE_ID;
+  readonly servicePriority: number;
+  #fetchService: DefaultFetchService | undefined;
+
+  public constructor(servicePriority: number) {
+    this.servicePriority = servicePriority;
+  }
+
+  public getServiceInfo(_cliConfig: CLIConfig): Promise<ServiceInfo> {
+    this.#fetchService = new DefaultFetchService();
+    return Promise.resolve({
+      service: this.#fetchService,
+      commands: [],
+    });
+  }
+
+  public initService(context: Context): Promise<void> {
+    const shutdownService = context.getServiceById(SHUTDOWN_SERVICE_ID) as ShutdownService;
+    this.#fetchService!.setDependencies(shutdownService);
+    return Promise.resolve();
+  }
+}

--- a/src/service/fetch/FetchServiceProvider.ts
+++ b/src/service/fetch/FetchServiceProvider.ts
@@ -1,4 +1,10 @@
-import type { CLIConfig, Context, ServiceInfo, ServiceProvider, ShutdownService } from "@flowscripter/dynamic-cli-framework-api";
+import type {
+  CLIConfig,
+  Context,
+  ServiceInfo,
+  ServiceProvider,
+  ShutdownService,
+} from "@flowscripter/dynamic-cli-framework-api";
 import { FETCH_SERVICE_ID, SHUTDOWN_SERVICE_ID } from "@flowscripter/dynamic-cli-framework-api";
 import DefaultFetchService from "./DefaultFetchService.ts";
 

--- a/src/service/plugin/DefaultPluginServiceProvider.ts
+++ b/src/service/plugin/DefaultPluginServiceProvider.ts
@@ -3,7 +3,10 @@ import type { Context } from "@flowscripter/dynamic-cli-framework-api";
 import type { CLIConfig } from "@flowscripter/dynamic-cli-framework-api";
 import type { PrinterService, SpawnService } from "@flowscripter/dynamic-cli-framework-api";
 import { PRINTER_SERVICE_ID, SPAWN_SERVICE_ID } from "@flowscripter/dynamic-cli-framework-api";
+import type { FetchService } from "@flowscripter/dynamic-cli-framework-api";
+import { FETCH_SERVICE_ID } from "@flowscripter/dynamic-cli-framework-api";
 import type {
+  FetchCapable,
   MarketplacePluginManager,
   SpawnCapable,
 } from "@flowscripter/dynamic-plugin-framework";
@@ -13,6 +16,9 @@ import { PluginGroupCommand } from "./command/PluginGroupCommand.ts";
 import SpawnInterfaceAdapter, {
   type SpawnInterfaceAdapterOptions,
 } from "./SpawnInterfaceAdapter.ts";
+import FetchInterfaceAdapter, {
+  type FetchInterfaceAdapterOptions,
+} from "./FetchInterfaceAdapter.ts";
 import getLogger from "../../util/logger.ts";
 
 const logger = getLogger("DefaultPluginServiceProvider");
@@ -22,16 +28,19 @@ export default class DefaultPluginServiceProvider implements ServiceProvider {
   readonly servicePriority: number;
   readonly #pluginManager: MarketplacePluginManager;
   readonly #spawnInterfaceAdapterOptions: SpawnInterfaceAdapterOptions;
+  readonly #fetchInterfaceAdapterOptions: FetchInterfaceAdapterOptions;
   #pluginService: DefaultPluginService | undefined;
 
   constructor(
     pluginManager: MarketplacePluginManager,
     servicePriority = 50,
     spawnInterfaceAdapterOptions: SpawnInterfaceAdapterOptions = {},
+    fetchInterfaceAdapterOptions: FetchInterfaceAdapterOptions = {},
   ) {
     this.#pluginManager = pluginManager;
     this.servicePriority = servicePriority;
     this.#spawnInterfaceAdapterOptions = spawnInterfaceAdapterOptions;
+    this.#fetchInterfaceAdapterOptions = fetchInterfaceAdapterOptions;
   }
 
   async getServiceInfo(_cliConfig: CLIConfig): Promise<ServiceInfo> {
@@ -45,21 +54,29 @@ export default class DefaultPluginServiceProvider implements ServiceProvider {
   initService(context: Context): Promise<void> {
     if (!context.doesServiceExist(SPAWN_SERVICE_ID)) {
       logger.debug("SpawnService not available, plugin manager will spawn processes directly");
-      return Promise.resolve();
-    }
-    if (!("setSpawn" in this.#pluginManager)) {
+    } else if (!("setSpawn" in this.#pluginManager)) {
       logger.debug("Plugin manager does not support SpawnCapable, skipping spawn injection");
-      return Promise.resolve();
+    } else {
+      const spawnService = context.getServiceById(SPAWN_SERVICE_ID) as SpawnService;
+      const printerService = context.getServiceById(PRINTER_SERVICE_ID) as PrinterService;
+      const adapter = new SpawnInterfaceAdapter(
+        spawnService,
+        printerService,
+        this.#spawnInterfaceAdapterOptions,
+      );
+      (this.#pluginManager as unknown as SpawnCapable).setSpawn(adapter);
     }
 
-    const spawnService = context.getServiceById(SPAWN_SERVICE_ID) as SpawnService;
-    const printerService = context.getServiceById(PRINTER_SERVICE_ID) as PrinterService;
-    const adapter = new SpawnInterfaceAdapter(
-      spawnService,
-      printerService,
-      this.#spawnInterfaceAdapterOptions,
-    );
-    (this.#pluginManager as unknown as SpawnCapable).setSpawn(adapter);
+    if (!context.doesServiceExist(FETCH_SERVICE_ID)) {
+      logger.debug("FetchService not available, plugin manager will fetch directly");
+    } else if (!("setFetch" in this.#pluginManager)) {
+      logger.debug("Plugin manager does not support FetchCapable, skipping fetch injection");
+    } else {
+      const fetchService = context.getServiceById(FETCH_SERVICE_ID) as FetchService;
+      const adapter = new FetchInterfaceAdapter(fetchService, this.#fetchInterfaceAdapterOptions);
+      (this.#pluginManager as unknown as FetchCapable).setFetch(adapter);
+    }
+
     return Promise.resolve();
   }
 }

--- a/src/service/plugin/FetchInterfaceAdapter.ts
+++ b/src/service/plugin/FetchInterfaceAdapter.ts
@@ -1,0 +1,28 @@
+import type { FetchService } from "@flowscripter/dynamic-cli-framework-api";
+import type { FetchInterface } from "@flowscripter/dynamic-plugin-framework";
+
+export interface FetchInterfaceAdapterOptions {
+  timeoutMs?: number;
+}
+
+/**
+ * Adapts a {@link FetchService} to dynamic-plugin-framework's {@link FetchInterface}, so plugin
+ * manager/repository fetches respect the host CLI's shutdown handling and default timeout.
+ */
+export default class FetchInterfaceAdapter implements FetchInterface {
+  readonly #fetchService: FetchService;
+  readonly #timeoutMs: number | undefined;
+
+  public constructor(fetchService: FetchService, options: FetchInterfaceAdapterOptions = {}) {
+    this.#fetchService = fetchService;
+    this.#timeoutMs = options.timeoutMs;
+  }
+
+  public async fetch(
+    input: string,
+    init?: RequestInit & { timeoutMs?: number },
+  ): Promise<Response> {
+    const { timeoutMs = this.#timeoutMs, ...requestInit } = init ?? {};
+    return this.#fetchService.fetch(input, { ...requestInit, timeoutMs });
+  }
+}

--- a/src/service/plugin/SpawnInterfaceAdapter.ts
+++ b/src/service/plugin/SpawnInterfaceAdapter.ts
@@ -45,7 +45,7 @@ export default class SpawnInterfaceAdapter implements SpawnInterface {
 
     const result = await this.#spawnService.spawn(command, {
       cwd: options.cwd,
-      stdio: "wrapped",
+      mode: "wrapped",
       onOutput,
     });
 

--- a/src/service/spawn/DefaultSpawnService.ts
+++ b/src/service/spawn/DefaultSpawnService.ts
@@ -95,10 +95,10 @@ export default class DefaultSpawnService implements SpawnService {
     }
     const printerService = this.#printerService;
     const shutdownService = this.#shutdownService;
-    const stdio = options.stdio ?? "inherit";
+    const mode = options.mode ?? "inherit";
     const longRunning = options.longRunning ?? true;
 
-    if (stdio === "inherit") {
+    if (mode === "inherit") {
       await printerService.hideSpinner();
       await printerService.hideAllProgressBars();
     }
@@ -107,9 +107,9 @@ export default class DefaultSpawnService implements SpawnService {
     try {
       proc = Bun.spawn(resolveForPlatform(command), {
         cwd: options.cwd,
-        stdin: stdio === "wrapped" ? "ignore" : "inherit",
-        stdout: stdio === "wrapped" ? "pipe" : "inherit",
-        stderr: stdio === "wrapped" ? "pipe" : "inherit",
+        stdin: mode === "inherit" ? "inherit" : "ignore",
+        stdout: mode === "wrapped" ? "pipe" : mode === "ignore" ? "ignore" : "inherit",
+        stderr: mode === "wrapped" ? "pipe" : mode === "ignore" ? "ignore" : "inherit",
       });
     } catch (error) {
       logger.debug(() => `Failed to launch command '${command.join(" ")}': ${error}`);
@@ -129,7 +129,7 @@ export default class DefaultSpawnService implements SpawnService {
       await this.#terminate(proc, command);
     });
 
-    if (stdio === "wrapped" && options.onOutput) {
+    if (mode === "wrapped" && options.onOutput) {
       const onOutput = options.onOutput;
       void this.#pipeLines(proc.stdout, "stdout", onOutput);
       void this.#pipeLines(proc.stderr, "stderr", onOutput);

--- a/src/service/upgrade/DefaultUpgradeService.ts
+++ b/src/service/upgrade/DefaultUpgradeService.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type {
   CLIConfig,
-  ShutdownService,
+  FetchService,
   SpawnResult,
   SpawnService,
   UpgradeCheckResult,
@@ -40,7 +40,7 @@ const OS_LABELS: Record<SupportedOs, string> = {
 
 export default class DefaultUpgradeService implements UpgradeService {
   #spawnService: SpawnService | undefined;
-  #shutdownService: ShutdownService | undefined;
+  #fetchService: FetchService | undefined;
   #upgradeCheckPromise: Promise<UpgradeCheckResult | undefined> | undefined;
   readonly #config: UpgradeLocationsConfig;
   readonly #cliConfig: CLIConfig;
@@ -50,9 +50,12 @@ export default class DefaultUpgradeService implements UpgradeService {
     this.#cliConfig = cliConfig;
   }
 
-  public setDependencies(spawnService: SpawnService, shutdownService?: ShutdownService): void {
+  public setDependencies(
+    spawnService: SpawnService | undefined,
+    fetchService: FetchService | undefined,
+  ): void {
     this.#spawnService = spawnService;
-    this.#shutdownService = shutdownService;
+    this.#fetchService = fetchService;
   }
 
   public getUpgradeCheckResult(waitForResult = false): Promise<UpgradeCheckResult | undefined> {
@@ -170,6 +173,9 @@ export default class DefaultUpgradeService implements UpgradeService {
     if (!this.#spawnService) {
       return { ok: false, oldVersion, error: new Error("SpawnService is not available") };
     }
+    if (checkResult.installMethod === InstallMethod.GITHUB_RELEASE && !this.#fetchService) {
+      return { ok: false, oldVersion, error: new Error("FetchService is not available") };
+    }
 
     try {
       switch (checkResult.installMethod) {
@@ -204,7 +210,7 @@ export default class DefaultUpgradeService implements UpgradeService {
     }
     const result = await this.#spawnService.spawn(
       ["brew", "list", "--versions", this.#config.homebrew.formula],
-      { stdio: "wrapped", longRunning: false, timeoutMs: VERSION_CHECK_TIMEOUT_MS },
+      { mode: "ignore", longRunning: false, timeoutMs: VERSION_CHECK_TIMEOUT_MS },
     );
     return result.ok;
   }
@@ -215,7 +221,7 @@ export default class DefaultUpgradeService implements UpgradeService {
     }
     const result = await this.#spawnService.spawn(
       ["winget", "list", "--id", this.#config.winget.packageId],
-      { stdio: "wrapped", longRunning: false, timeoutMs: VERSION_CHECK_TIMEOUT_MS },
+      { mode: "ignore", longRunning: false, timeoutMs: VERSION_CHECK_TIMEOUT_MS },
     );
     return result.ok;
   }
@@ -239,14 +245,14 @@ export default class DefaultUpgradeService implements UpgradeService {
   }
 
   async #getLatestGithubReleaseVersion(): Promise<string | undefined> {
-    if (!this.#config.githubRelease) {
+    if (!this.#config.githubRelease || !this.#fetchService) {
       return undefined;
     }
     const { owner, repo } = this.#config.githubRelease;
     try {
-      const response = await fetch(
+      const response = await this.#fetchService.fetch(
         `https://api.github.com/repos/${owner}/${repo}/releases/latest`,
-        { signal: AbortSignal.timeout(VERSION_CHECK_TIMEOUT_MS) },
+        { timeoutMs: VERSION_CHECK_TIMEOUT_MS },
       );
       if (!response.ok) {
         return undefined;
@@ -260,7 +266,7 @@ export default class DefaultUpgradeService implements UpgradeService {
   }
 
   async #getLatestHomebrewVersion(): Promise<string | undefined> {
-    if (!this.#config.homebrew) {
+    if (!this.#config.homebrew || !this.#fetchService) {
       return undefined;
     }
     const { tap, formula } = this.#config.homebrew;
@@ -269,9 +275,9 @@ export default class DefaultUpgradeService implements UpgradeService {
       return undefined;
     }
     try {
-      const response = await fetch(
+      const response = await this.#fetchService.fetch(
         `https://raw.githubusercontent.com/${tapOwner}/homebrew-${tapName}/main/${formula}.rb`,
-        { signal: AbortSignal.timeout(VERSION_CHECK_TIMEOUT_MS) },
+        { timeoutMs: VERSION_CHECK_TIMEOUT_MS },
       );
       if (!response.ok) {
         return undefined;
@@ -292,7 +298,7 @@ export default class DefaultUpgradeService implements UpgradeService {
     const result = await this.#spawnService.spawn(
       ["winget", "show", "--id", this.#config.winget.packageId],
       {
-        stdio: "wrapped",
+        mode: "wrapped",
         longRunning: false,
         timeoutMs: VERSION_CHECK_TIMEOUT_MS,
         onOutput: (line) => lines.push(line),
@@ -312,7 +318,9 @@ export default class DefaultUpgradeService implements UpgradeService {
 
   async #upgradeViaLinuxScript(): Promise<void> {
     const { scriptUrl } = this.#config.linuxScript!;
-    const result = await this.#spawnService!.spawn(["sh", "-c", `curl -fsSL ${scriptUrl} | sh`]);
+    const result = await this.#spawnService!.spawn(["sh", "-c", `curl -fsSL ${scriptUrl} | sh`], {
+      mode: "ignore",
+    });
     if (!result.ok) {
       throw new Error(`Install script failed: ${describeSpawnFailure(result)}`);
     }
@@ -320,7 +328,9 @@ export default class DefaultUpgradeService implements UpgradeService {
 
   async #upgradeViaHomebrew(): Promise<void> {
     const { tap, formula } = this.#config.homebrew!;
-    const result = await this.#spawnService!.spawn(["brew", "upgrade", `${tap}/${formula}`]);
+    const result = await this.#spawnService!.spawn(["brew", "upgrade", `${tap}/${formula}`], {
+      mode: "ignore",
+    });
     if (!result.ok) {
       throw new Error(`brew upgrade failed: ${describeSpawnFailure(result)}`);
     }
@@ -328,15 +338,18 @@ export default class DefaultUpgradeService implements UpgradeService {
 
   async #upgradeViaWinget(): Promise<void> {
     const { packageId } = this.#config.winget!;
-    const result = await this.#spawnService!.spawn([
-      "winget",
-      "upgrade",
-      "--id",
-      packageId,
-      "--silent",
-      "--accept-package-agreements",
-      "--accept-source-agreements",
-    ]);
+    const result = await this.#spawnService!.spawn(
+      [
+        "winget",
+        "upgrade",
+        "--id",
+        packageId,
+        "--silent",
+        "--accept-package-agreements",
+        "--accept-source-agreements",
+      ],
+      { mode: "ignore" },
+    );
     if (!result.ok) {
       throw new Error(`winget upgrade failed: ${describeSpawnFailure(result)}`);
     }
@@ -349,19 +362,13 @@ export default class DefaultUpgradeService implements UpgradeService {
     const assetName = assetPattern.replace("{os}", OS_LABELS[os]).replace("{arch}", archLabel);
     const url = `https://github.com/${owner}/${repo}/releases/latest/download/${assetName}`;
 
-    // Downloading the release asset but enter long-running mode to get cooperative
-    // Ctrl-C handling during what can be the slowest step of the upgrade.
-    this.#shutdownService?.enterLongRunningMode();
-    let archiveData: ArrayBuffer;
-    try {
-      const response = await fetch(url);
-      if (!response.ok) {
-        throw new Error(`Failed to download release asset '${assetName}': HTTP ${response.status}`);
-      }
-      archiveData = await response.arrayBuffer();
-    } finally {
-      this.#shutdownService?.leaveLongRunningMode();
+    // longRunning: true gets cooperative Ctrl-C handling during what can be the slowest step of
+    // the upgrade.
+    const response = await this.#fetchService!.fetch(url, { longRunning: true });
+    if (!response.ok) {
+      throw new Error(`Failed to download release asset '${assetName}': HTTP ${response.status}`);
     }
+    const archiveData = await response.arrayBuffer();
 
     const tmpDir = await mkdtemp(join(tmpdir(), "upgrade-"));
     const archivePath = join(tmpDir, assetName);
@@ -370,52 +377,43 @@ export default class DefaultUpgradeService implements UpgradeService {
     const currentExecutable = process.execPath;
 
     if (os === SupportedOs.WINDOWS) {
-      const extractResult = await this.#spawnService!.spawn([
-        "powershell",
-        "-Command",
-        `Expand-Archive -Path '${archivePath}' -DestinationPath '${tmpDir}' -Force`,
-      ]);
+      const extractResult = await this.#spawnService!.spawn(
+        [
+          "powershell",
+          "-Command",
+          `Expand-Archive -Path '${archivePath}' -DestinationPath '${tmpDir}' -Force`,
+        ],
+        { mode: "ignore" },
+      );
       if (!extractResult.ok) {
         throw new Error("Failed to extract release archive");
       }
       const extractedBinary = join(tmpDir, `${this.#cliConfig.name}.exe`);
       const oldPath = `${currentExecutable}.old.exe`;
-      const moveResult = await this.#spawnService!.spawn([
-        "cmd",
-        "/c",
-        "move",
-        "/y",
-        currentExecutable,
-        oldPath,
-      ]);
+      const moveResult = await this.#spawnService!.spawn(
+        ["cmd", "/c", "move", "/y", currentExecutable, oldPath],
+        { mode: "ignore" },
+      );
       if (!moveResult.ok) {
         throw new Error("Failed to move current executable aside");
       }
-      const copyResult = await this.#spawnService!.spawn([
-        "cmd",
-        "/c",
-        "copy",
-        "/y",
-        extractedBinary,
-        currentExecutable,
-      ]);
+      const copyResult = await this.#spawnService!.spawn(
+        ["cmd", "/c", "copy", "/y", extractedBinary, currentExecutable],
+        { mode: "ignore" },
+      );
       if (!copyResult.ok) {
         throw new Error("Failed to copy new executable into place");
       }
     } else {
-      const extractResult = await this.#spawnService!.spawn([
-        "unzip",
-        "-o",
-        archivePath,
-        "-d",
-        tmpDir,
-      ]);
+      const extractResult = await this.#spawnService!.spawn(["unzip", "-o", archivePath, "-d", tmpDir], {
+        mode: "ignore",
+      });
       if (!extractResult.ok) {
         throw new Error("Failed to extract release archive");
       }
       const extractedBinary = join(tmpDir, this.#cliConfig.name);
       await Bun.write(currentExecutable, Bun.file(extractedBinary));
-      await this.#spawnService!.spawn(["chmod", "+x", currentExecutable]);
+      await this.#spawnService!.spawn(["chmod", "+x", currentExecutable], { mode: "ignore" });
     }
   }
 }

--- a/src/service/upgrade/DefaultUpgradeService.ts
+++ b/src/service/upgrade/DefaultUpgradeService.ts
@@ -405,9 +405,12 @@ export default class DefaultUpgradeService implements UpgradeService {
         throw new Error("Failed to copy new executable into place");
       }
     } else {
-      const extractResult = await this.#spawnService!.spawn(["unzip", "-o", archivePath, "-d", tmpDir], {
-        mode: "ignore",
-      });
+      const extractResult = await this.#spawnService!.spawn(
+        ["unzip", "-o", archivePath, "-d", tmpDir],
+        {
+          mode: "ignore",
+        },
+      );
       if (!extractResult.ok) {
         throw new Error("Failed to extract release archive");
       }

--- a/src/service/upgrade/UpgradeServiceProvider.ts
+++ b/src/service/upgrade/UpgradeServiceProvider.ts
@@ -8,8 +8,8 @@ import { KEY_VALUE_SERVICE_ID } from "@flowscripter/dynamic-cli-framework-api";
 import type { KeyValueService } from "@flowscripter/dynamic-cli-framework-api";
 import { SPAWN_SERVICE_ID } from "@flowscripter/dynamic-cli-framework-api";
 import type { SpawnService } from "@flowscripter/dynamic-cli-framework-api";
-import { SHUTDOWN_SERVICE_ID } from "@flowscripter/dynamic-cli-framework-api";
-import type { ShutdownService } from "@flowscripter/dynamic-cli-framework-api";
+import { FETCH_SERVICE_ID } from "@flowscripter/dynamic-cli-framework-api";
+import type { FetchService } from "@flowscripter/dynamic-cli-framework-api";
 import { Icon, PRINTER_SERVICE_ID } from "@flowscripter/dynamic-cli-framework-api";
 import type { PrinterService } from "@flowscripter/dynamic-cli-framework-api";
 import DefaultUpgradeService from "./DefaultUpgradeService.ts";
@@ -44,15 +44,19 @@ export default class UpgradeServiceProvider implements ServiceProvider {
     const upgradeService = this.#upgradeService!;
     const cliConfig = this.#cliConfig!;
 
-    if (context.doesServiceExist(SPAWN_SERVICE_ID)) {
-      const spawnService = context.getServiceById(SPAWN_SERVICE_ID) as SpawnService;
-      const shutdownService = context.doesServiceExist(SHUTDOWN_SERVICE_ID)
-        ? (context.getServiceById(SHUTDOWN_SERVICE_ID) as ShutdownService)
-        : undefined;
-      upgradeService.setDependencies(spawnService, shutdownService);
-    } else {
+    const spawnService = context.doesServiceExist(SPAWN_SERVICE_ID)
+      ? (context.getServiceById(SPAWN_SERVICE_ID) as SpawnService)
+      : undefined;
+    const fetchService = context.doesServiceExist(FETCH_SERVICE_ID)
+      ? (context.getServiceById(FETCH_SERVICE_ID) as FetchService)
+      : undefined;
+    if (spawnService === undefined) {
       logger.debug(() => "SpawnService not available, upgrade install methods will be unavailable");
     }
+    if (fetchService === undefined) {
+      logger.debug(() => "FetchService not available, upgrade version checks will be unavailable");
+    }
+    upgradeService.setDependencies(spawnService, fetchService);
 
     void upgradeService.getUpgradeCheckResult();
 

--- a/tests/service/fetch/DefaultFetchService.test.ts
+++ b/tests/service/fetch/DefaultFetchService.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import DefaultFetchService from "../../../src/service/fetch/DefaultFetchService.ts";
+import type { ShutdownService } from "@flowscripter/dynamic-cli-framework-api";
+
+interface FakeShutdownServiceState {
+  enterLongRunningModeCalls: number;
+  leaveLongRunningModeCalls: number;
+  listeners: Array<() => Promise<void>>;
+}
+
+function getFakeShutdownService(): {
+  shutdownService: ShutdownService;
+  state: FakeShutdownServiceState;
+} {
+  const state: FakeShutdownServiceState = {
+    enterLongRunningModeCalls: 0,
+    leaveLongRunningModeCalls: 0,
+    listeners: [],
+  };
+  const shutdownService: ShutdownService = {
+    addShutdownListener: (callback) => {
+      state.listeners.push(callback);
+    },
+    enterLongRunningMode: () => {
+      state.enterLongRunningModeCalls++;
+    },
+    leaveLongRunningMode: () => {
+      state.leaveLongRunningModeCalls++;
+    },
+    isShutdownRequested: false,
+  };
+  return { shutdownService, state };
+}
+
+describe("DefaultFetchService tests", () => {
+  let server: ReturnType<typeof Bun.serve>;
+  let baseUrl: string;
+
+  beforeEach(() => {
+    server = Bun.serve({
+      port: 0,
+      fetch: (request) => {
+        const url = new URL(request.url);
+        if (url.pathname === "/slow") {
+          return new Promise(() => {});
+        }
+        if (url.pathname === "/echo-method") {
+          return new Response(request.method);
+        }
+        return new Response("ok");
+      },
+    });
+    baseUrl = `http://localhost:${server.port}`;
+  });
+
+  afterEach(() => {
+    server.stop(true);
+  });
+
+  test("fetch() throws if called before setDependencies()", () => {
+    const service = new DefaultFetchService();
+
+    expect(service.fetch(baseUrl)).rejects.toThrow(
+      "DefaultFetchService.fetch() called before setDependencies()",
+    );
+  });
+
+  test("fetch() resolves the Response for a successful request", async () => {
+    const service = new DefaultFetchService();
+    const { shutdownService } = getFakeShutdownService();
+    service.setDependencies(shutdownService);
+
+    const response = await service.fetch(baseUrl);
+
+    expect(response.ok).toBe(true);
+    expect(await response.text()).toEqual("ok");
+  });
+
+  test("fetch() passes through RequestInit fields such as method", async () => {
+    const service = new DefaultFetchService();
+    const { shutdownService } = getFakeShutdownService();
+    service.setDependencies(shutdownService);
+
+    const response = await service.fetch(`${baseUrl}/echo-method`, { method: "POST" });
+
+    expect(await response.text()).toEqual("POST");
+  });
+
+  test("fetch() rejects with a TimeoutError DOMException when timeoutMs elapses", async () => {
+    const service = new DefaultFetchService();
+    const { shutdownService } = getFakeShutdownService();
+    service.setDependencies(shutdownService);
+
+    await expect(service.fetch(`${baseUrl}/slow`, { timeoutMs: 50 })).rejects.toMatchObject({
+      name: "TimeoutError",
+    });
+  });
+
+  test("fetch() does not enter long-running mode by default", async () => {
+    const service = new DefaultFetchService();
+    const { shutdownService, state } = getFakeShutdownService();
+    service.setDependencies(shutdownService);
+
+    await service.fetch(baseUrl);
+
+    expect(state.enterLongRunningModeCalls).toEqual(0);
+    expect(state.listeners.length).toEqual(0);
+  });
+
+  test("fetch() enters and leaves long-running mode and registers a shutdown listener when longRunning is true", async () => {
+    const service = new DefaultFetchService();
+    const { shutdownService, state } = getFakeShutdownService();
+    service.setDependencies(shutdownService);
+
+    await service.fetch(baseUrl, { longRunning: true });
+
+    expect(state.enterLongRunningModeCalls).toEqual(1);
+    expect(state.leaveLongRunningModeCalls).toEqual(1);
+    expect(state.listeners.length).toEqual(1);
+  });
+
+  test("shutdown listener aborts an in-flight longRunning fetch with an AbortError", async () => {
+    const service = new DefaultFetchService();
+    const { shutdownService, state } = getFakeShutdownService();
+    service.setDependencies(shutdownService);
+
+    const pending = service.fetch(`${baseUrl}/slow`, { longRunning: true });
+    // Wait for the fetch to register its shutdown listener before invoking it.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(state.listeners.length).toEqual(1);
+    await state.listeners[0]!();
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+  });
+});

--- a/tests/service/fetch/FetchServiceProvider.test.ts
+++ b/tests/service/fetch/FetchServiceProvider.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import FetchServiceProvider from "../../../src/service/fetch/FetchServiceProvider.ts";
+import DefaultContext from "../../../src/runtime/DefaultContext.ts";
+import type { CLIConfig } from "@flowscripter/dynamic-cli-framework-api";
+import { SHUTDOWN_SERVICE_ID } from "@flowscripter/dynamic-cli-framework-api";
+import type { FetchService } from "@flowscripter/dynamic-cli-framework-api";
+
+function getCLIConfig(): CLIConfig {
+  return { name: "testcli", description: "Test CLI", version: "1.0.0" };
+}
+
+describe("FetchServiceProvider tests", () => {
+  test("has correct serviceId", () => {
+    const provider = new FetchServiceProvider(57);
+    expect(provider.serviceId).toEqual("@flowscripter/dynamic-cli-framework/fetch-service");
+  });
+
+  test("has correct servicePriority", () => {
+    const provider = new FetchServiceProvider(57);
+    expect(provider.servicePriority).toEqual(57);
+  });
+
+  test("getServiceInfo returns a service with no commands", async () => {
+    const provider = new FetchServiceProvider(57);
+    const serviceInfo = await provider.getServiceInfo(getCLIConfig());
+
+    expect(serviceInfo.service).toBeDefined();
+    expect(serviceInfo.commands.length).toEqual(0);
+  });
+
+  test("initService wires ShutdownService into the service returned by getServiceInfo", async () => {
+    const provider = new FetchServiceProvider(57);
+    const serviceInfo = await provider.getServiceInfo(getCLIConfig());
+    const fetchService = serviceInfo.service as FetchService;
+
+    const context = new DefaultContext(getCLIConfig());
+    context.addServiceInstance(SHUTDOWN_SERVICE_ID, {
+      addShutdownListener: () => {},
+      enterLongRunningMode: () => {},
+      leaveLongRunningMode: () => {},
+      isShutdownRequested: false,
+    });
+
+    await provider.initService(context);
+
+    const server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
+    try {
+      const response = await fetchService.fetch(`http://localhost:${server.port}`);
+      expect(await response.text()).toEqual("ok");
+    } finally {
+      server.stop(true);
+    }
+  });
+});

--- a/tests/service/spawn/DefaultSpawnService.test.ts
+++ b/tests/service/spawn/DefaultSpawnService.test.ts
@@ -112,7 +112,7 @@ describe("DefaultSpawnService tests", () => {
 
     const lines: Array<{ line: string; stream: "stdout" | "stderr" }> = [];
     const result = await service.spawn(["sh", "-c", "echo out1; echo err1 >&2"], {
-      stdio: "wrapped",
+      mode: "wrapped",
       onOutput: (line, stream) => lines.push({ line, stream }),
     });
 
@@ -185,12 +185,27 @@ describe("DefaultSpawnService tests", () => {
     service.setDependencies(printerService, shutdownService);
 
     const result = await service.spawn(["sh", "-c", "sleep 30"], {
-      stdio: "wrapped",
+      mode: "wrapped",
       longRunning: false,
       timeoutMs: 100,
     });
 
     expect(result).toEqual({ ok: false, timedOut: true });
+  });
+
+  test("spawn() with mode ignore discards output and does not touch the printer", async () => {
+    const service = new DefaultSpawnService();
+    const { printerService, state } = getFakePrinterService();
+    const { shutdownService } = getFakeShutdownService();
+    service.setDependencies(printerService, shutdownService);
+
+    const result = await service.spawn(["sh", "-c", "echo out1; echo err1 >&2"], {
+      mode: "ignore",
+    });
+
+    expect(result).toEqual({ ok: true, exitCode: 0 });
+    expect(state.hideSpinnerCalls).toEqual(0);
+    expect(state.hideAllProgressBarsCalls).toEqual(0);
   });
 });
 

--- a/tests/service/upgrade/DefaultUpgradeService.test.ts
+++ b/tests/service/upgrade/DefaultUpgradeService.test.ts
@@ -147,9 +147,7 @@ describe("DefaultUpgradeService", () => {
     );
     service.setDependencies(
       undefined,
-      getFetchService(() =>
-        new Response(JSON.stringify({ tag_name: "v9.9.9" }), { status: 200 }),
-      ),
+      getFetchService(() => new Response(JSON.stringify({ tag_name: "v9.9.9" }), { status: 200 })),
     );
     const result = await service.checkForUpgrade(
       SupportedOs.LINUX,
@@ -170,9 +168,7 @@ describe("DefaultUpgradeService", () => {
     );
     service.setDependencies(
       undefined,
-      getFetchService(() =>
-        new Response(JSON.stringify({ tag_name: "v0.0.0" }), { status: 200 }),
-      ),
+      getFetchService(() => new Response(JSON.stringify({ tag_name: "v0.0.0" }), { status: 200 })),
     );
     const result = await service.checkForUpgrade(
       SupportedOs.LINUX,
@@ -262,9 +258,7 @@ describe("DefaultUpgradeService", () => {
     );
     service.setDependencies(
       undefined,
-      getFetchService(() =>
-        new Response(JSON.stringify({ tag_name: "v9.9.9" }), { status: 200 }),
-      ),
+      getFetchService(() => new Response(JSON.stringify({ tag_name: "v9.9.9" }), { status: 200 })),
     );
     const result = await service.upgrade(
       SupportedOs.LINUX,

--- a/tests/service/upgrade/DefaultUpgradeService.test.ts
+++ b/tests/service/upgrade/DefaultUpgradeService.test.ts
@@ -1,7 +1,12 @@
 import process from "node:process";
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { InstallMethod, SupportedArch, SupportedOs } from "@flowscripter/dynamic-cli-framework-api";
-import type { SpawnResult, SpawnService } from "@flowscripter/dynamic-cli-framework-api";
+import type {
+  FetchOptions,
+  FetchService,
+  SpawnResult,
+  SpawnService,
+} from "@flowscripter/dynamic-cli-framework-api";
 import type { CLIConfig } from "@flowscripter/dynamic-cli-framework-api";
 import DefaultUpgradeService, {
   VERSION_CHECK_TIMEOUT_MS,
@@ -32,17 +37,15 @@ function getSpawnService(handler: (command: ReadonlyArray<string>) => SpawnResul
   };
 }
 
+function getFetchService(
+  handler: (input: string | URL, options?: FetchOptions) => Response | Promise<Response>,
+): FetchService {
+  return {
+    fetch: (input, options) => Promise.resolve(handler(input, options)),
+  };
+}
+
 describe("DefaultUpgradeService", () => {
-  let originalFetch: typeof fetch;
-
-  beforeEach(() => {
-    originalFetch = globalThis.fetch;
-  });
-
-  afterEach(() => {
-    globalThis.fetch = originalFetch;
-  });
-
   test("detectOs maps process.platform to the current OS", () => {
     const service = new DefaultUpgradeService(getConfig(), getCLIConfig());
     const expected =
@@ -89,7 +92,10 @@ describe("DefaultUpgradeService", () => {
       getConfig({ homebrew: { tap: "flowscripter/tap", formula: "example-cli" } }),
       getCLIConfig(),
     );
-    service.setDependencies(getSpawnService(() => ({ ok: true, exitCode: 0 })));
+    service.setDependencies(
+      getSpawnService(() => ({ ok: true, exitCode: 0 })),
+      undefined,
+    );
     expect(await service.detectInstallMethod(SupportedOs.MACOS)).toEqual(InstallMethod.HOMEBREW);
   });
 
@@ -101,14 +107,17 @@ describe("DefaultUpgradeService", () => {
       }),
       getCLIConfig(),
     );
-    service.setDependencies({
-      // Mimics DefaultSpawnService's real timeoutMs handling: a stalled process resolves
-      // { ok: false, timedOut: true } once the caller-specified timeoutMs elapses.
-      spawn: (_command, options) =>
-        options?.timeoutMs === undefined
-          ? new Promise(() => {})
-          : Promise.resolve({ ok: false, timedOut: true }),
-    });
+    service.setDependencies(
+      {
+        // Mimics DefaultSpawnService's real timeoutMs handling: a stalled process resolves
+        // { ok: false, timedOut: true } once the caller-specified timeoutMs elapses.
+        spawn: (_command, options) =>
+          options?.timeoutMs === undefined
+            ? new Promise(() => {})
+            : Promise.resolve({ ok: false, timedOut: true }),
+      },
+      undefined,
+    );
     expect(await service.detectInstallMethod(SupportedOs.WINDOWS)).toEqual(
       InstallMethod.GITHUB_RELEASE,
     );
@@ -130,16 +139,17 @@ describe("DefaultUpgradeService", () => {
   });
 
   test("checkForUpgrade reports updateAvailable when latest GitHub release is newer", async () => {
-    globalThis.fetch = (() =>
-      Promise.resolve(
-        new Response(JSON.stringify({ tag_name: "v9.9.9" }), { status: 200 }),
-      )) as unknown as typeof fetch;
-
     const service = new DefaultUpgradeService(
       getConfig({
         githubRelease: { owner: "flowscripter", repo: "example-cli", assetPattern: "x" },
       }),
       getCLIConfig(),
+    );
+    service.setDependencies(
+      undefined,
+      getFetchService(() =>
+        new Response(JSON.stringify({ tag_name: "v9.9.9" }), { status: 200 }),
+      ),
     );
     const result = await service.checkForUpgrade(
       SupportedOs.LINUX,
@@ -152,16 +162,17 @@ describe("DefaultUpgradeService", () => {
   });
 
   test("checkForUpgrade reports no update available when already latest", async () => {
-    globalThis.fetch = (() =>
-      Promise.resolve(
-        new Response(JSON.stringify({ tag_name: "v0.0.0" }), { status: 200 }),
-      )) as unknown as typeof fetch;
-
     const service = new DefaultUpgradeService(
       getConfig({
         githubRelease: { owner: "flowscripter", repo: "example-cli", assetPattern: "x" },
       }),
       getCLIConfig(),
+    );
+    service.setDependencies(
+      undefined,
+      getFetchService(() =>
+        new Response(JSON.stringify({ tag_name: "v0.0.0" }), { status: 200 }),
+      ),
     );
     const result = await service.checkForUpgrade(
       SupportedOs.LINUX,
@@ -171,37 +182,39 @@ describe("DefaultUpgradeService", () => {
     expect(result?.updateAvailable).toBe(false);
   });
 
-  test("checkForUpgrade passes a bounded AbortSignal to the GitHub release lookup", async () => {
-    let receivedSignal: AbortSignal | undefined;
-    globalThis.fetch = ((_url: string, init?: RequestInit) => {
-      receivedSignal = init?.signal ?? undefined;
-      return Promise.resolve(new Response(JSON.stringify({ tag_name: "v9.9.9" }), { status: 200 }));
-    }) as unknown as typeof fetch;
-
+  test("checkForUpgrade passes VERSION_CHECK_TIMEOUT_MS as timeoutMs to the GitHub release lookup", async () => {
+    let receivedOptions: FetchOptions | undefined;
     const service = new DefaultUpgradeService(
       getConfig({
         githubRelease: { owner: "flowscripter", repo: "example-cli", assetPattern: "x" },
       }),
       getCLIConfig(),
+    );
+    service.setDependencies(
+      undefined,
+      getFetchService((_input, options) => {
+        receivedOptions = options;
+        return new Response(JSON.stringify({ tag_name: "v9.9.9" }), { status: 200 });
+      }),
     );
     await service.checkForUpgrade(
       SupportedOs.LINUX,
       SupportedArch.X64,
       InstallMethod.GITHUB_RELEASE,
     );
-    expect(receivedSignal).toBeInstanceOf(AbortSignal);
-    expect(receivedSignal?.aborted).toBe(false);
+    expect(receivedOptions?.timeoutMs).toEqual(VERSION_CHECK_TIMEOUT_MS);
   });
 
   test("checkForUpgrade returns undefined when fetch fails", async () => {
-    globalThis.fetch = (() =>
-      Promise.reject(new Error("network error"))) as unknown as typeof fetch;
-
     const service = new DefaultUpgradeService(
       getConfig({
         githubRelease: { owner: "flowscripter", repo: "example-cli", assetPattern: "x" },
       }),
       getCLIConfig(),
+    );
+    service.setDependencies(
+      undefined,
+      getFetchService(() => Promise.reject(new Error("network error"))),
     );
     const result = await service.checkForUpgrade(
       SupportedOs.LINUX,
@@ -212,16 +225,18 @@ describe("DefaultUpgradeService", () => {
   });
 
   test("checkForUpgrade resolves latest homebrew version from tap formula file", async () => {
-    globalThis.fetch = ((url: string) => {
-      expect(url).toEqual(
-        "https://raw.githubusercontent.com/flowscripter/homebrew-tap/main/example-cli.rb",
-      );
-      return Promise.resolve(new Response('version "v9.9.9"', { status: 200 }));
-    }) as unknown as typeof fetch;
-
     const service = new DefaultUpgradeService(
       getConfig({ homebrew: { tap: "flowscripter/tap", formula: "example-cli" } }),
       getCLIConfig(),
+    );
+    service.setDependencies(
+      undefined,
+      getFetchService((url) => {
+        expect(url).toEqual(
+          "https://raw.githubusercontent.com/flowscripter/homebrew-tap/main/example-cli.rb",
+        );
+        return new Response('version "v9.9.9"', { status: 200 });
+      }),
     );
     const result = await service.checkForUpgrade(
       SupportedOs.MACOS,
@@ -239,16 +254,17 @@ describe("DefaultUpgradeService", () => {
   });
 
   test("upgrade returns error when SpawnService not available", async () => {
-    globalThis.fetch = (() =>
-      Promise.resolve(
-        new Response(JSON.stringify({ tag_name: "v9.9.9" }), { status: 200 }),
-      )) as unknown as typeof fetch;
-
     const service = new DefaultUpgradeService(
       getConfig({
         githubRelease: { owner: "flowscripter", repo: "example-cli", assetPattern: "x" },
       }),
       getCLIConfig(),
+    );
+    service.setDependencies(
+      undefined,
+      getFetchService(() =>
+        new Response(JSON.stringify({ tag_name: "v9.9.9" }), { status: 200 }),
+      ),
     );
     const result = await service.upgrade(
       SupportedOs.LINUX,
@@ -260,11 +276,6 @@ describe("DefaultUpgradeService", () => {
   });
 
   test("upgrade via homebrew invokes 'brew upgrade' and returns new version", async () => {
-    globalThis.fetch = (() =>
-      Promise.resolve(
-        new Response('version "v9.9.9"', { status: 200 }),
-      )) as unknown as typeof fetch;
-
     const spawnedCommands: ReadonlyArray<string>[] = [];
     const service = new DefaultUpgradeService(
       getConfig({ homebrew: { tap: "flowscripter/tap", formula: "example-cli" } }),
@@ -275,6 +286,7 @@ describe("DefaultUpgradeService", () => {
         spawnedCommands.push(command);
         return { ok: true, exitCode: 0 };
       }),
+      getFetchService(() => new Response('version "v9.9.9"', { status: 200 })),
     );
 
     const result = await service.upgrade(
@@ -288,16 +300,14 @@ describe("DefaultUpgradeService", () => {
   });
 
   test("upgrade via homebrew reports failure when brew upgrade fails", async () => {
-    globalThis.fetch = (() =>
-      Promise.resolve(
-        new Response('version "v9.9.9"', { status: 200 }),
-      )) as unknown as typeof fetch;
-
     const service = new DefaultUpgradeService(
       getConfig({ homebrew: { tap: "flowscripter/tap", formula: "example-cli" } }),
       getCLIConfig(),
     );
-    service.setDependencies(getSpawnService(() => ({ ok: false, exitCode: 1 })));
+    service.setDependencies(
+      getSpawnService(() => ({ ok: false, exitCode: 1 })),
+      getFetchService(() => new Response('version "v9.9.9"', { status: 200 })),
+    );
 
     const result = await service.upgrade(
       SupportedOs.MACOS,
@@ -310,16 +320,18 @@ describe("DefaultUpgradeService", () => {
 
   test("getUpgradeCheckResult caches the same promise across calls", async () => {
     let checkCount = 0;
-    globalThis.fetch = (() => {
-      checkCount++;
-      return Promise.resolve(new Response(JSON.stringify({ tag_name: "v9.9.9" }), { status: 200 }));
-    }) as unknown as typeof fetch;
-
     const service = new DefaultUpgradeService(
       getConfig({
         githubRelease: { owner: "flowscripter", repo: "example-cli", assetPattern: "x" },
       }),
       getCLIConfig(),
+    );
+    service.setDependencies(
+      undefined,
+      getFetchService(() => {
+        checkCount++;
+        return new Response(JSON.stringify({ tag_name: "v9.9.9" }), { status: 200 });
+      }),
     );
 
     const first = service.getUpgradeCheckResult(true);
@@ -337,7 +349,10 @@ describe("DefaultUpgradeService", () => {
       }),
       getCLIConfig(),
     );
-    globalThis.fetch = (() => new Promise(() => {})) as unknown as typeof fetch;
+    service.setDependencies(
+      undefined,
+      getFetchService(() => new Promise(() => {})),
+    );
 
     const result = await service.getUpgradeCheckResult();
     expect(result).toBeUndefined();
@@ -350,24 +365,24 @@ describe("DefaultUpgradeService", () => {
       }),
       getCLIConfig(),
     );
-    globalThis.fetch = (() =>
-      new Promise((resolve) =>
-        setTimeout(
-          () => resolve(new Response(JSON.stringify({ tag_name: "v9.9.9" }), { status: 200 })),
-          VERSION_CHECK_TIMEOUT_MS + 50,
-        ),
-      )) as unknown as typeof fetch;
+    service.setDependencies(
+      undefined,
+      getFetchService(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(
+              () => resolve(new Response(JSON.stringify({ tag_name: "v9.9.9" }), { status: 200 })),
+              VERSION_CHECK_TIMEOUT_MS + 50,
+            ),
+          ),
+      ),
+    );
 
     const result = await service.getUpgradeCheckResult(true);
     expect(result?.latestVersion).toEqual("9.9.9");
   });
 
   test("upgrade bypasses the cached check when an override is passed", async () => {
-    globalThis.fetch = (() =>
-      Promise.resolve(
-        new Response('version "v9.9.9"', { status: 200 }),
-      )) as unknown as typeof fetch;
-
     const spawnedCommands: ReadonlyArray<string>[] = [];
     const service = new DefaultUpgradeService(
       getConfig({ homebrew: { tap: "flowscripter/tap", formula: "example-cli" } }),
@@ -378,6 +393,7 @@ describe("DefaultUpgradeService", () => {
         spawnedCommands.push(command);
         return { ok: true, exitCode: 0 };
       }),
+      getFetchService(() => new Response('version "v9.9.9"', { status: 200 })),
     );
 
     // Prime the cache with default (no-override) detection, which resolves undefined since


### PR DESCRIPTION
## Summary
- Adds `FetchService`/`FetchServiceProvider` (mirroring `SpawnService`'s pattern): a `fetch()` wrapper with an optional `timeoutMs` and cooperation with `ShutdownService`'s long-running mode. Opt-in via `fetchServiceEnabled` on `BaseCLI`.
- Renames `SpawnOptions.stdio` to `mode` and adds `mode: "ignore"` to fully discard a spawned process's output.
- `DefaultUpgradeService` now looks up `FetchService` for its three `fetch()` call sites (GitHub release version check, Homebrew formula check, GitHub release asset download) instead of calling `fetch()` directly, and uses `mode: "ignore"` for all its `SpawnService` invocations except `getLatestWingetVersion()` (still `mode: "wrapped"`, since it needs the captured output to parse the version).
- `DefaultPluginServiceProvider` now also injects a `FetchInterfaceAdapter` (mirroring `SpawnInterfaceAdapter`) into plugin managers/repositories implementing dynamic-plugin-framework's new `FetchCapable`.
- Updates `README/core-service-providers.md` with the new `FetchServiceProvider` section and touches up the `SpawnServiceProvider`/`UpgradeServiceProvider` sections for the `mode` rename and the new `FetchService` dependency.

Depends on flowscripter/dynamic-cli-framework-api#6 and flowscripter/dynamic-plugin-framework#99 - `package.json` dependency version bumps to follow once those are published (this branch was verified locally against those branches' sources).

## Test plan
- [x] `bun test` - 759 pass (includes new `DefaultFetchService`/`FetchServiceProvider` tests and updated `DefaultUpgradeService`/`DefaultSpawnService` tests)
- [x] `bun run build` (tsc) passes
- [x] `bunx oxlint index.ts src/ tests/` passes