### PR TITLE
fix: don't permanently cache a transient upgrade-check failure

### DIFF
--- a/src/service/upgrade/DefaultUpgradeService.ts
+++ b/src/service/upgrade/DefaultUpgradeService.ts
@@ -60,7 +60,17 @@ export default class DefaultUpgradeService implements UpgradeService {
 
   public getUpgradeCheckResult(waitForResult = false): Promise<UpgradeCheckResult | undefined> {
     if (!this.#upgradeCheckPromise) {
-      this.#upgradeCheckPromise = this.checkForUpgrade();
+      // Only cache a successful result. An `undefined` result can come from a transient
+      // failure (e.g. the opportunistic startup check's fetch exceeding
+      // VERSION_CHECK_TIMEOUT_MS) - caching that would permanently deny a later, deliberate
+      // caller (e.g. the `upgrade` command explicitly waiting via waitForResult=true) any
+      // chance of a fresh attempt for the rest of this process's lifetime.
+      this.#upgradeCheckPromise = this.checkForUpgrade().then((result) => {
+        if (result === undefined) {
+          this.#upgradeCheckPromise = undefined;
+        }
+        return result;
+      });
     }
     if (waitForResult) {
       return this.#upgradeCheckPromise;

--- a/tests/service/upgrade/DefaultUpgradeService.test.ts
+++ b/tests/service/upgrade/DefaultUpgradeService.test.ts
@@ -352,6 +352,38 @@ describe("DefaultUpgradeService", () => {
     expect(result).toBeUndefined();
   });
 
+  test("a transient timeout on an opportunistic check does not poison a later deliberate wait", async () => {
+    let callCount = 0;
+    const service = new DefaultUpgradeService(
+      getConfig({
+        githubRelease: { owner: "flowscripter", repo: "example-cli", assetPattern: "x" },
+      }),
+      getCLIConfig(),
+    );
+    service.setDependencies(
+      undefined,
+      getFetchService(() => {
+        callCount++;
+        // first call (simulating the opportunistic startup check) fails as if its own
+        // internal timeoutMs fired; subsequent calls resolve immediately.
+        if (callCount === 1) {
+          throw new Error("simulated fetch timeout");
+        }
+        return new Response(JSON.stringify({ tag_name: "v9.9.9" }), { status: 200 });
+      }),
+    );
+
+    // opportunistic, non-blocking call - its underlying fetch fails immediately.
+    const opportunistic = await service.getUpgradeCheckResult();
+    expect(opportunistic).toBeUndefined();
+
+    // a later, deliberate blocking call (e.g. the `upgrade` command) must get a fresh attempt
+    // rather than reusing the earlier timed-out promise forever.
+    const deliberate = await service.getUpgradeCheckResult(true);
+    expect(deliberate?.latestVersion).toEqual("9.9.9");
+    expect(callCount).toEqual(2);
+  });
+
   test("getUpgradeCheckResult(true) waits for the full result with no timeout", async () => {
     const service = new DefaultUpgradeService(
       getConfig({


### PR DESCRIPTION
## Summary
- `DefaultUpgradeService.getUpgradeCheckResult()` memoizes the version-check promise for the lifetime of the process and reuses it for every subsequent caller, including the explicit, blocking `upgrade` command (`waitForResult=true`).
- The opportunistic startup check (fired via `BannerServiceProvider`) races that same promise against `VERSION_CHECK_TIMEOUT_MS` (250ms) - intentionally tight so it never stalls CLI startup.
- If that first check's underlying fetch exceeds its own timeout and resolves to `undefined`, the failure gets memoized forever - permanently denying the deliberate, patience-tolerant `upgrade` command any real result for the rest of that process's lifetime.
- Fix: only cache a successful (non-`undefined`) result. An `undefined` resolution clears the cache so the next caller (e.g. the explicit `upgrade` command moments later) gets a genuine fresh attempt instead of reusing a doomed one.

Root-caused while investigating a consistently-failing `upgrade` functional test in `example-cli` (flowscripter/example-cli#81), after enabling `fetchServiceEnabled` there for the first time.

## Test plan
- [x] New unit test: a transient timeout on an opportunistic (non-blocking) check no longer poisons a later deliberate (`waitForResult=true`) call.
- [x] `bunx tsc --noEmit`, `bun test` (760 pass), `bunx oxlint .`, `bunx oxfmt --check .` all clean.