### PR TITLE
fix: don't apply opportunistic-check timeout to real upgrade-check network calls

### DIFF
--- a/src/service/upgrade/DefaultUpgradeService.ts
+++ b/src/service/upgrade/DefaultUpgradeService.ts
@@ -23,7 +23,9 @@ import getLogger from "../../util/logger.ts";
 const logger = getLogger("DefaultUpgradeService");
 
 // checkForUpgrade() runs opportunistically on every CLI invocation (via BannerServiceProvider),
-// so its version-check network/spawn calls must never be allowed to stall CLI startup.
+// so that opportunistic call is raced against this timeout so it never stalls CLI startup.
+// A deliberate caller (waitForResult=true, e.g. the `upgrade` command) awaits checkForUpgrade()
+// directly with no timeout, so its underlying network/spawn calls are never artificially cut off.
 export const VERSION_CHECK_TIMEOUT_MS = 250;
 
 function describeSpawnFailure(result: Extract<SpawnResult, { ok: false }>): string {
@@ -61,10 +63,11 @@ export default class DefaultUpgradeService implements UpgradeService {
   public getUpgradeCheckResult(waitForResult = false): Promise<UpgradeCheckResult | undefined> {
     if (!this.#upgradeCheckPromise) {
       // Only cache a successful result. An `undefined` result can come from a transient
-      // failure (e.g. the opportunistic startup check's fetch exceeding
-      // VERSION_CHECK_TIMEOUT_MS) - caching that would permanently deny a later, deliberate
-      // caller (e.g. the `upgrade` command explicitly waiting via waitForResult=true) any
-      // chance of a fresh attempt for the rest of this process's lifetime.
+      // failure (e.g. the opportunistic startup check racing past VERSION_CHECK_TIMEOUT_MS
+      // before checkForUpgrade() itself resolves) - caching that would permanently deny a
+      // later, deliberate caller (e.g. the `upgrade` command explicitly waiting via
+      // waitForResult=true) any chance of a fresh attempt for the rest of this process's
+      // lifetime.
       this.#upgradeCheckPromise = this.checkForUpgrade().then((result) => {
         if (result === undefined) {
           this.#upgradeCheckPromise = undefined;
@@ -220,7 +223,7 @@ export default class DefaultUpgradeService implements UpgradeService {
     }
     const result = await this.#spawnService.spawn(
       ["brew", "list", "--versions", this.#config.homebrew.formula],
-      { mode: "ignore", longRunning: false, timeoutMs: VERSION_CHECK_TIMEOUT_MS },
+      { mode: "ignore", longRunning: false },
     );
     return result.ok;
   }
@@ -231,7 +234,7 @@ export default class DefaultUpgradeService implements UpgradeService {
     }
     const result = await this.#spawnService.spawn(
       ["winget", "list", "--id", this.#config.winget.packageId],
-      { mode: "ignore", longRunning: false, timeoutMs: VERSION_CHECK_TIMEOUT_MS },
+      { mode: "ignore", longRunning: false },
     );
     return result.ok;
   }
@@ -262,7 +265,6 @@ export default class DefaultUpgradeService implements UpgradeService {
     try {
       const response = await this.#fetchService.fetch(
         `https://api.github.com/repos/${owner}/${repo}/releases/latest`,
-        { timeoutMs: VERSION_CHECK_TIMEOUT_MS },
       );
       if (!response.ok) {
         return undefined;
@@ -287,7 +289,6 @@ export default class DefaultUpgradeService implements UpgradeService {
     try {
       const response = await this.#fetchService.fetch(
         `https://raw.githubusercontent.com/${tapOwner}/homebrew-${tapName}/main/${formula}.rb`,
-        { timeoutMs: VERSION_CHECK_TIMEOUT_MS },
       );
       if (!response.ok) {
         return undefined;
@@ -310,7 +311,6 @@ export default class DefaultUpgradeService implements UpgradeService {
       {
         mode: "wrapped",
         longRunning: false,
-        timeoutMs: VERSION_CHECK_TIMEOUT_MS,
         onOutput: (line) => lines.push(line),
       },
     );

--- a/tests/service/upgrade/DefaultUpgradeService.test.ts
+++ b/tests/service/upgrade/DefaultUpgradeService.test.ts
@@ -99,30 +99,6 @@ describe("DefaultUpgradeService", () => {
     expect(await service.detectInstallMethod(SupportedOs.MACOS)).toEqual(InstallMethod.HOMEBREW);
   });
 
-  test("detectInstallMethod falls through to GITHUB_RELEASE if the winget check times out", async () => {
-    const service = new DefaultUpgradeService(
-      getConfig({
-        winget: { packageId: "Flowscripter.example-cli" },
-        githubRelease: { owner: "flowscripter", repo: "example-cli", assetPattern: "x" },
-      }),
-      getCLIConfig(),
-    );
-    service.setDependencies(
-      {
-        // Mimics DefaultSpawnService's real timeoutMs handling: a stalled process resolves
-        // { ok: false, timedOut: true } once the caller-specified timeoutMs elapses.
-        spawn: (_command, options) =>
-          options?.timeoutMs === undefined
-            ? new Promise(() => {})
-            : Promise.resolve({ ok: false, timedOut: true }),
-      },
-      undefined,
-    );
-    expect(await service.detectInstallMethod(SupportedOs.WINDOWS)).toEqual(
-      InstallMethod.GITHUB_RELEASE,
-    );
-  });
-
   test("checkForUpgrade returns undefined for unsupported platform", async () => {
     const service = new DefaultUpgradeService(
       getConfig({ supportedPlatforms: [] }),
@@ -178,7 +154,7 @@ describe("DefaultUpgradeService", () => {
     expect(result?.updateAvailable).toBe(false);
   });
 
-  test("checkForUpgrade passes VERSION_CHECK_TIMEOUT_MS as timeoutMs to the GitHub release lookup", async () => {
+  test("checkForUpgrade does not pass a timeoutMs to the GitHub release lookup", async () => {
     let receivedOptions: FetchOptions | undefined;
     const service = new DefaultUpgradeService(
       getConfig({
@@ -198,7 +174,7 @@ describe("DefaultUpgradeService", () => {
       SupportedArch.X64,
       InstallMethod.GITHUB_RELEASE,
     );
-    expect(receivedOptions?.timeoutMs).toEqual(VERSION_CHECK_TIMEOUT_MS);
+    expect(receivedOptions?.timeoutMs).toBeUndefined();
   });
 
   test("checkForUpgrade returns undefined when fetch fails", async () => {


### PR DESCRIPTION
## Summary
- \`VERSION_CHECK_TIMEOUT_MS\` (250ms) was applied both to the opportunistic startup-check race (its intended use) and, incorrectly, as \`timeoutMs\` on every underlying \`brew\`/\`winget\` spawn and GitHub/Homebrew/Winget \`fetch\` call.
- This meant a deliberate, blocking caller (e.g. the \`upgrade\` command via \`waitForResult=true\`) also had its real network I/O cut off after 250ms - nowhere near enough for a genuine HTTPS round trip from CI infra - producing a misleading "No upgrade location is configured for the detected or requested platform" failure.
- Found while diagnosing an intermittent \`macOS-latest\` functional-test failure in example-cli#81's \`upgrade\` scenario.

## Changes
- Removed \`timeoutMs: VERSION_CHECK_TIMEOUT_MS\` from the five underlying spawn/fetch call sites in \`DefaultUpgradeService\`.
- \`VERSION_CHECK_TIMEOUT_MS\` is now used solely to race the opportunistic startup check; deliberate callers await \`checkForUpgrade()\` to natural completion with no artificial cutoff.
- Updated/removed two unit tests that asserted the old (now removed) per-call timeout behavior.

## Test plan
- [x] \`tsc --noEmit\` passes
- [x] \`bun test\` - 759 pass, 0 fail
- [x] \`oxlint\` / \`oxfmt --check\` clean