### PR TITLE
feat!: adopt typed upgrade-check result and non-rate-limited GitHub endpoint

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@flowscripter/dynamic-cli-framework",
       "dependencies": {
-        "@flowscripter/dynamic-cli-framework-api": "^1.5.0",
+        "@flowscripter/dynamic-cli-framework-api": "^2.0.0",
         "@flowscripter/dynamic-plugin-framework": "2.0.0",
         "emphasize": "^7.0.0",
         "fastest-levenshtein": "^1.0.16",
@@ -29,7 +29,7 @@
     },
   },
   "packages": {
-    "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@1.5.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-Tjs5rtaL7kEVZAdO2bM1vdbzCp5R5qGJxRFif6T1uilV5qQaVF92t1R90ndjSSb9G9KnyTDdhHe+NbpDOllvtA=="],
+    "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@2.0.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-jeSfXanm+RED9zKSxStOJYmDRi3t7bAaDNSQxI+KhraUMb0iTt+TiWPmDZyBN/Bc76hDX9W/lqN7041OALl2pA=="],
 
     "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@2.0.0", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-LPq4JXqsWttvNgE7Z5fim3h78xfeF/754gL7yI4PMjxfIvAZeyJhqsUElXOMEzNIrY9bXTqVWQJBpKO0+Vl61A=="],
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "build": "tsc -p tsconfig.build.json"
   },
   "dependencies": {
-    "@flowscripter/dynamic-cli-framework-api": "^1.5.0",
+    "@flowscripter/dynamic-cli-framework-api": "^2.0.0",
     "@flowscripter/dynamic-plugin-framework": "2.0.0",
     "emphasize": "^7.0.0",
     "fastest-levenshtein": "^1.0.16",

--- a/src/command/VersionCommand.ts
+++ b/src/command/VersionCommand.ts
@@ -19,8 +19,8 @@ export default class VersionCommand implements GlobalCommand {
     let line = context.cliConfig.version;
     if (context.doesServiceExist(UPGRADE_SERVICE_ID)) {
       const upgradeService = context.getServiceById(UPGRADE_SERVICE_ID) as UpgradeService;
-      const result = await upgradeService.getUpgradeCheckResult().catch(() => undefined);
-      if (result?.updateAvailable) {
+      const result = await upgradeService.getUpgradeCheckResult();
+      if (result.status === "checked" && result.updateAvailable) {
         line += ` (${result.latestVersion} available, run '${context.cliConfig.name} upgrade')`;
       }
     }

--- a/src/service/banner/BannerServiceProvider.ts
+++ b/src/service/banner/BannerServiceProvider.ts
@@ -72,8 +72,8 @@ export default class BannerServiceProvider implements ServiceProvider {
     }
     if (context.doesServiceExist(UPGRADE_SERVICE_ID)) {
       const upgradeService = context.getServiceById(UPGRADE_SERVICE_ID) as UpgradeService;
-      const result = await upgradeService.getUpgradeCheckResult().catch(() => undefined);
-      if (result?.updateAvailable) {
+      const result = await upgradeService.getUpgradeCheckResult();
+      if (result.status === "checked" && result.updateAvailable) {
         await printerService.info(
           `  ${printerService.secondary(
             `(${result.latestVersion} available, run '${cliConfig.name} upgrade')`,

--- a/src/service/upgrade/DefaultUpgradeService.ts
+++ b/src/service/upgrade/DefaultUpgradeService.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type {
   CLIConfig,
+  CompletedUpgradeCheckResult,
   FetchService,
   SpawnResult,
   SpawnService,
@@ -18,15 +19,16 @@ import {
 } from "@flowscripter/dynamic-cli-framework-api";
 import semver from "semver";
 import type { UpgradeLocationsConfig } from "./UpgradeLocationsConfig.ts";
-import getLogger from "../../util/logger.ts";
-
-const logger = getLogger("DefaultUpgradeService");
 
 // checkForUpgrade() runs opportunistically on every CLI invocation (via BannerServiceProvider),
 // so that opportunistic call is raced against this timeout so it never stalls CLI startup.
 // A deliberate caller (waitForResult=true, e.g. the `upgrade` command) awaits checkForUpgrade()
 // directly with no timeout, so its underlying network/spawn calls are never artificially cut off.
 export const VERSION_CHECK_TIMEOUT_MS = 250;
+
+type VersionLookupResult =
+  | { readonly ok: true; readonly version: string }
+  | { readonly ok: false; readonly error: Error };
 
 function describeSpawnFailure(result: Extract<SpawnResult, { ok: false }>): string {
   return "timedOut" in result
@@ -43,7 +45,7 @@ const OS_LABELS: Record<SupportedOs, string> = {
 export default class DefaultUpgradeService implements UpgradeService {
   #spawnService: SpawnService | undefined;
   #fetchService: FetchService | undefined;
-  #upgradeCheckPromise: Promise<UpgradeCheckResult | undefined> | undefined;
+  #upgradeCheckPromise: Promise<CompletedUpgradeCheckResult> | undefined;
   readonly #config: UpgradeLocationsConfig;
   readonly #cliConfig: CLIConfig;
 
@@ -60,16 +62,18 @@ export default class DefaultUpgradeService implements UpgradeService {
     this.#fetchService = fetchService;
   }
 
-  public getUpgradeCheckResult(waitForResult = false): Promise<UpgradeCheckResult | undefined> {
+  public getUpgradeCheckResult(waitForResult: true): Promise<CompletedUpgradeCheckResult>;
+  public getUpgradeCheckResult(waitForResult?: boolean): Promise<UpgradeCheckResult>;
+  public getUpgradeCheckResult(waitForResult = false): Promise<UpgradeCheckResult> {
     if (!this.#upgradeCheckPromise) {
-      // Only cache a successful result. An `undefined` result can come from a transient
-      // failure (e.g. the opportunistic startup check racing past VERSION_CHECK_TIMEOUT_MS
-      // before checkForUpgrade() itself resolves) - caching that would permanently deny a
-      // later, deliberate caller (e.g. the `upgrade` command explicitly waiting via
-      // waitForResult=true) any chance of a fresh attempt for the rest of this process's
-      // lifetime.
+      // Only cache a non-"failed" result. A "failed" result can come from a transient issue
+      // (e.g. a network blip, or the opportunistic startup check racing past
+      // VERSION_CHECK_TIMEOUT_MS before checkForUpgrade() itself resolves) - caching that would
+      // permanently deny a later, deliberate caller (e.g. the `upgrade` command explicitly
+      // waiting via waitForResult=true) any chance of a fresh attempt for the rest of this
+      // process's lifetime.
       this.#upgradeCheckPromise = this.checkForUpgrade().then((result) => {
-        if (result === undefined) {
+        if (result.status === "failed") {
           this.#upgradeCheckPromise = undefined;
         }
         return result;
@@ -80,8 +84,8 @@ export default class DefaultUpgradeService implements UpgradeService {
     }
     return Promise.race([
       this.#upgradeCheckPromise,
-      new Promise<undefined>((resolve) =>
-        setTimeout(() => resolve(undefined), VERSION_CHECK_TIMEOUT_MS),
+      new Promise<UpgradeCheckResult>((resolve) =>
+        setTimeout(() => resolve({ status: "pending" }), VERSION_CHECK_TIMEOUT_MS),
       ),
     ]);
   }
@@ -130,34 +134,39 @@ export default class DefaultUpgradeService implements UpgradeService {
     osOverride?: SupportedOs,
     archOverride?: SupportedArch,
     installMethodOverride?: InstallMethod,
-  ): Promise<UpgradeCheckResult | undefined> {
+  ): Promise<CompletedUpgradeCheckResult> {
     const os = osOverride ?? this.detectOs();
     const arch = archOverride ?? this.detectArch();
     if (!os || !arch || !this.#isPlatformSupported(os, arch)) {
-      return undefined;
+      return { status: "unsupported" };
     }
 
     const installMethod = installMethodOverride ?? (await this.detectInstallMethod(os));
     if (!installMethod) {
-      return undefined;
+      return { status: "unsupported" };
     }
 
-    const latestVersion = await this.#getLatestVersion(installMethod);
-    if (!latestVersion) {
-      return undefined;
+    const versionLookup = await this.#getLatestVersion(installMethod);
+    if (!versionLookup.ok) {
+      return { status: "failed", error: versionLookup.error };
     }
 
     const currentVersion = this.#cliConfig.version;
     const coercedCurrent = semver.coerce(currentVersion);
-    const coercedLatest = semver.coerce(latestVersion);
+    const coercedLatest = semver.coerce(versionLookup.version);
     if (!coercedCurrent || !coercedLatest) {
-      logger.debug(() => `Unable to compare versions '${currentVersion}' and '${latestVersion}'`);
-      return undefined;
+      return {
+        status: "failed",
+        error: new Error(
+          `Unable to compare versions '${currentVersion}' and '${versionLookup.version}'`,
+        ),
+      };
     }
 
     return {
+      status: "checked",
       currentVersion,
-      latestVersion,
+      latestVersion: versionLookup.version,
       updateAvailable: semver.gt(coercedLatest, coercedCurrent),
       os,
       arch,
@@ -176,12 +185,15 @@ export default class DefaultUpgradeService implements UpgradeService {
     const checkResult = hasOverride
       ? await this.checkForUpgrade(osOverride, archOverride, installMethodOverride)
       : await this.getUpgradeCheckResult(true);
-    if (!checkResult) {
+    if (checkResult.status === "unsupported") {
       return {
         ok: false,
         oldVersion,
         error: new Error("No upgrade location configured for the detected or requested platform"),
       };
+    }
+    if (checkResult.status === "failed") {
+      return { ok: false, oldVersion, error: checkResult.error };
     }
     if (!this.#spawnService) {
       return { ok: false, oldVersion, error: new Error("SpawnService is not available") };
@@ -243,7 +255,7 @@ export default class DefaultUpgradeService implements UpgradeService {
     return process.execPath.startsWith("/usr/local/bin/");
   }
 
-  async #getLatestVersion(installMethod: InstallMethod): Promise<string | undefined> {
+  async #getLatestVersion(installMethod: InstallMethod): Promise<VersionLookupResult> {
     switch (installMethod) {
       case InstallMethod.GITHUB_RELEASE:
       case InstallMethod.LINUX_SCRIPT:
@@ -252,58 +264,91 @@ export default class DefaultUpgradeService implements UpgradeService {
         return this.#getLatestHomebrewVersion();
       case InstallMethod.WINGET:
         return this.#getLatestWingetVersion();
-      default:
-        return undefined;
     }
   }
 
-  async #getLatestGithubReleaseVersion(): Promise<string | undefined> {
-    if (!this.#config.githubRelease || !this.#fetchService) {
-      return undefined;
+  async #getLatestGithubReleaseVersion(): Promise<VersionLookupResult> {
+    if (!this.#config.githubRelease) {
+      return { ok: false, error: new Error("No githubRelease location configured") };
+    }
+    if (!this.#fetchService) {
+      return { ok: false, error: new Error("FetchService is not available") };
     }
     const { owner, repo } = this.#config.githubRelease;
     try {
+      // Uses the plain web redirect rather than the api.github.com REST endpoint, since the
+      // latter's unauthenticated rate limit (60 requests/hour/IP) is easily exhausted, e.g. by
+      // CI runners sharing an IP pool.
       const response = await this.#fetchService.fetch(
-        `https://api.github.com/repos/${owner}/${repo}/releases/latest`,
+        `https://github.com/${owner}/${repo}/releases/latest`,
+        { redirect: "manual" },
       );
-      if (!response.ok) {
-        return undefined;
+      const location = response.headers.get("location");
+      const version = location ? /\/releases\/tag\/v?([^/]+)$/.exec(location)?.[1] : undefined;
+      if (!version) {
+        return {
+          ok: false,
+          error: new Error(
+            `Unexpected response resolving latest release for ${owner}/${repo}: HTTP ${response.status}`,
+          ),
+        };
       }
-      const data = (await response.json()) as { tag_name?: string };
-      return data.tag_name?.replace(/^v/, "");
+      return { ok: true, version };
     } catch (error) {
-      logger.debug(() => `Failed to fetch latest GitHub release for ${owner}/${repo}: ${error}`);
-      return undefined;
+      return {
+        ok: false,
+        error: new Error(`Failed to fetch latest GitHub release for ${owner}/${repo}: ${error}`),
+      };
     }
   }
 
-  async #getLatestHomebrewVersion(): Promise<string | undefined> {
-    if (!this.#config.homebrew || !this.#fetchService) {
-      return undefined;
+  async #getLatestHomebrewVersion(): Promise<VersionLookupResult> {
+    if (!this.#config.homebrew) {
+      return { ok: false, error: new Error("No homebrew location configured") };
+    }
+    if (!this.#fetchService) {
+      return { ok: false, error: new Error("FetchService is not available") };
     }
     const { tap, formula } = this.#config.homebrew;
     const [tapOwner, tapName] = tap.split("/");
     if (!tapOwner || !tapName) {
-      return undefined;
+      return { ok: false, error: new Error(`Invalid homebrew tap '${tap}'`) };
     }
     try {
       const response = await this.#fetchService.fetch(
         `https://raw.githubusercontent.com/${tapOwner}/homebrew-${tapName}/main/${formula}.rb`,
       );
       if (!response.ok) {
-        return undefined;
+        return {
+          ok: false,
+          error: new Error(
+            `Failed to fetch homebrew formula for ${tap}/${formula}: HTTP ${response.status}`,
+          ),
+        };
       }
       const text = await response.text();
-      return /version\s+"v?([^"]+)"/.exec(text)?.[1];
+      const version = /version\s+"v?([^"]+)"/.exec(text)?.[1];
+      if (!version) {
+        return {
+          ok: false,
+          error: new Error(`Could not parse version from homebrew formula ${tap}/${formula}`),
+        };
+      }
+      return { ok: true, version };
     } catch (error) {
-      logger.debug(() => `Failed to fetch homebrew formula for ${tap}/${formula}: ${error}`);
-      return undefined;
+      return {
+        ok: false,
+        error: new Error(`Failed to fetch homebrew formula for ${tap}/${formula}: ${error}`),
+      };
     }
   }
 
-  async #getLatestWingetVersion(): Promise<string | undefined> {
-    if (!this.#spawnService || !this.#config.winget) {
-      return undefined;
+  async #getLatestWingetVersion(): Promise<VersionLookupResult> {
+    if (!this.#config.winget) {
+      return { ok: false, error: new Error("No winget location configured") };
+    }
+    if (!this.#spawnService) {
+      return { ok: false, error: new Error("SpawnService is not available") };
     }
     const lines: string[] = [];
     const result = await this.#spawnService.spawn(
@@ -315,15 +360,15 @@ export default class DefaultUpgradeService implements UpgradeService {
       },
     );
     if (!result.ok) {
-      return undefined;
+      return { ok: false, error: new Error(`winget show failed: ${describeSpawnFailure(result)}`) };
     }
     for (const line of lines) {
       const match = /Version:\s*(\S+)/.exec(line);
       if (match?.[1]) {
-        return match[1];
+        return { ok: true, version: match[1] };
       }
     }
-    return undefined;
+    return { ok: false, error: new Error("Could not parse version from winget output") };
   }
 
   async #upgradeViaLinuxScript(): Promise<void> {

--- a/src/service/upgrade/DefaultUpgradeService.ts
+++ b/src/service/upgrade/DefaultUpgradeService.ts
@@ -4,7 +4,6 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type {
   CLIConfig,
-  CompletedUpgradeCheckResult,
   FetchService,
   SpawnResult,
   SpawnService,
@@ -45,7 +44,7 @@ const OS_LABELS: Record<SupportedOs, string> = {
 export default class DefaultUpgradeService implements UpgradeService {
   #spawnService: SpawnService | undefined;
   #fetchService: FetchService | undefined;
-  #upgradeCheckPromise: Promise<CompletedUpgradeCheckResult> | undefined;
+  #upgradeCheckPromise: Promise<UpgradeCheckResult> | undefined;
   readonly #config: UpgradeLocationsConfig;
   readonly #cliConfig: CLIConfig;
 
@@ -62,8 +61,6 @@ export default class DefaultUpgradeService implements UpgradeService {
     this.#fetchService = fetchService;
   }
 
-  public getUpgradeCheckResult(waitForResult: true): Promise<CompletedUpgradeCheckResult>;
-  public getUpgradeCheckResult(waitForResult?: boolean): Promise<UpgradeCheckResult>;
   public getUpgradeCheckResult(waitForResult = false): Promise<UpgradeCheckResult> {
     if (!this.#upgradeCheckPromise) {
       // Only cache a non-"failed" result. A "failed" result can come from a transient issue
@@ -134,7 +131,7 @@ export default class DefaultUpgradeService implements UpgradeService {
     osOverride?: SupportedOs,
     archOverride?: SupportedArch,
     installMethodOverride?: InstallMethod,
-  ): Promise<CompletedUpgradeCheckResult> {
+  ): Promise<UpgradeCheckResult> {
     const os = osOverride ?? this.detectOs();
     const arch = archOverride ?? this.detectArch();
     if (!os || !arch || !this.#isPlatformSupported(os, arch)) {
@@ -194,6 +191,10 @@ export default class DefaultUpgradeService implements UpgradeService {
     }
     if (checkResult.status === "failed") {
       return { ok: false, oldVersion, error: checkResult.error };
+    }
+    if (checkResult.status === "pending") {
+      // Unreachable: checkForUpgrade() and getUpgradeCheckResult(true) always run to completion.
+      return { ok: false, oldVersion, error: new Error("Upgrade check did not complete") };
     }
     if (!this.#spawnService) {
       return { ok: false, oldVersion, error: new Error("SpawnService is not available") };

--- a/src/service/upgrade/UpgradeServiceProvider.ts
+++ b/src/service/upgrade/UpgradeServiceProvider.ts
@@ -135,7 +135,11 @@ export default class UpgradeServiceProvider implements ServiceProvider {
   ): Promise<void> {
     try {
       const checkResult = await upgradeService.getUpgradeCheckResult();
-      if (!checkResult?.updateAvailable) {
+      if (checkResult.status === "failed") {
+        logger.debug(() => `Auto-upgrade check failed: ${checkResult.error.message}`);
+        return;
+      }
+      if (checkResult.status !== "checked" || !checkResult.updateAvailable) {
         return;
       }
       const upgradeResult = await upgradeService.upgrade();

--- a/src/service/upgrade/command/UpgradeSubCommand.ts
+++ b/src/service/upgrade/command/UpgradeSubCommand.ts
@@ -53,9 +53,17 @@ export class UpgradeSubCommand implements SubCommand {
       os === undefined && installMethod === undefined
         ? await this.#upgradeService.getUpgradeCheckResult(true)
         : await this.#upgradeService.checkForUpgrade(os, arch, installMethod);
-    if (!checkResult) {
+    if (checkResult.status === "unsupported") {
       await printerService.error(
         `No upgrade location is configured for the detected or requested platform.\n`,
+        Icon.FAILURE,
+      );
+      return;
+    }
+
+    if (checkResult.status === "failed") {
+      await printerService.error(
+        `Failed to check for updates: ${checkResult.error.message}. Please try again later.\n`,
         Icon.FAILURE,
       );
       return;

--- a/src/service/upgrade/command/UpgradeSubCommand.ts
+++ b/src/service/upgrade/command/UpgradeSubCommand.ts
@@ -69,6 +69,12 @@ export class UpgradeSubCommand implements SubCommand {
       return;
     }
 
+    if (checkResult.status === "pending") {
+      // Unreachable: getUpgradeCheckResult(true) and checkForUpgrade() always run to completion.
+      await printerService.error(`Failed to check for updates.\n`, Icon.FAILURE);
+      return;
+    }
+
     if (!checkResult.updateAvailable) {
       await printerService.print(
         `${cliName} is already up to date (${checkResult.currentVersion}).\n`,

--- a/tests/command/VersionCommand.test.ts
+++ b/tests/command/VersionCommand.test.ts
@@ -55,6 +55,7 @@ describe("VersionCommand tests", () => {
     context.addServiceInstance(UPGRADE_SERVICE_ID, {
       getUpgradeCheckResult: () =>
         Promise.resolve({
+          status: "checked",
           currentVersion: "foobar",
           latestVersion: "9.9.9",
           updateAvailable: true,
@@ -86,7 +87,7 @@ describe("VersionCommand tests", () => {
 
     context.addServiceInstance(PRINTER_SERVICE_ID, printer);
     context.addServiceInstance(UPGRADE_SERVICE_ID, {
-      getUpgradeCheckResult: () => Promise.resolve({ updateAvailable: false }),
+      getUpgradeCheckResult: () => Promise.resolve({ status: "unsupported" }),
     });
 
     const versionCommand = new VersionCommand();

--- a/tests/service/banner/BannerServiceProvider.test.ts
+++ b/tests/service/banner/BannerServiceProvider.test.ts
@@ -108,6 +108,7 @@ describe("BannerServiceProvider tests", () => {
     context.addServiceInstance(UPGRADE_SERVICE_ID, {
       getUpgradeCheckResult: () =>
         Promise.resolve({
+          status: "checked",
           currentVersion: "foobar",
           latestVersion: "9.9.9",
           updateAvailable: true,

--- a/tests/service/upgrade/DefaultUpgradeService.test.ts
+++ b/tests/service/upgrade/DefaultUpgradeService.test.ts
@@ -45,6 +45,13 @@ function getFetchService(
   };
 }
 
+function githubReleaseRedirect(version: string): Response {
+  return new Response(null, {
+    status: 302,
+    headers: { location: `https://github.com/flowscripter/example-cli/releases/tag/v${version}` },
+  });
+}
+
 describe("DefaultUpgradeService", () => {
   test("detectOs maps process.platform to the current OS", () => {
     const service = new DefaultUpgradeService(getConfig(), getCLIConfig());
@@ -99,19 +106,19 @@ describe("DefaultUpgradeService", () => {
     expect(await service.detectInstallMethod(SupportedOs.MACOS)).toEqual(InstallMethod.HOMEBREW);
   });
 
-  test("checkForUpgrade returns undefined for unsupported platform", async () => {
+  test("checkForUpgrade reports unsupported for unsupported platform", async () => {
     const service = new DefaultUpgradeService(
       getConfig({ supportedPlatforms: [] }),
       getCLIConfig(),
     );
     const result = await service.checkForUpgrade(SupportedOs.LINUX, SupportedArch.X64);
-    expect(result).toBeUndefined();
+    expect(result).toEqual({ status: "unsupported" });
   });
 
-  test("checkForUpgrade returns undefined when no install method resolved", async () => {
+  test("checkForUpgrade reports unsupported when no install method resolved", async () => {
     const service = new DefaultUpgradeService(getConfig(), getCLIConfig());
     const result = await service.checkForUpgrade(SupportedOs.LINUX, SupportedArch.X64);
-    expect(result).toBeUndefined();
+    expect(result).toEqual({ status: "unsupported" });
   });
 
   test("checkForUpgrade reports updateAvailable when latest GitHub release is newer", async () => {
@@ -123,16 +130,17 @@ describe("DefaultUpgradeService", () => {
     );
     service.setDependencies(
       undefined,
-      getFetchService(() => new Response(JSON.stringify({ tag_name: "v9.9.9" }), { status: 200 })),
+      getFetchService(() => githubReleaseRedirect("9.9.9")),
     );
     const result = await service.checkForUpgrade(
       SupportedOs.LINUX,
       SupportedArch.X64,
       InstallMethod.GITHUB_RELEASE,
     );
-    expect(result?.updateAvailable).toBe(true);
-    expect(result?.latestVersion).toEqual("9.9.9");
-    expect(result?.currentVersion).toEqual(getCLIConfig().version);
+    if (result.status !== "checked") throw new Error(`expected "checked", got ${result.status}`);
+    expect(result.updateAvailable).toBe(true);
+    expect(result.latestVersion).toEqual("9.9.9");
+    expect(result.currentVersion).toEqual(getCLIConfig().version);
   });
 
   test("checkForUpgrade reports no update available when already latest", async () => {
@@ -144,14 +152,15 @@ describe("DefaultUpgradeService", () => {
     );
     service.setDependencies(
       undefined,
-      getFetchService(() => new Response(JSON.stringify({ tag_name: "v0.0.0" }), { status: 200 })),
+      getFetchService(() => githubReleaseRedirect("0.0.0")),
     );
     const result = await service.checkForUpgrade(
       SupportedOs.LINUX,
       SupportedArch.X64,
       InstallMethod.GITHUB_RELEASE,
     );
-    expect(result?.updateAvailable).toBe(false);
+    if (result.status !== "checked") throw new Error(`expected "checked", got ${result.status}`);
+    expect(result.updateAvailable).toBe(false);
   });
 
   test("checkForUpgrade does not pass a timeoutMs to the GitHub release lookup", async () => {
@@ -166,7 +175,7 @@ describe("DefaultUpgradeService", () => {
       undefined,
       getFetchService((_input, options) => {
         receivedOptions = options;
-        return new Response(JSON.stringify({ tag_name: "v9.9.9" }), { status: 200 });
+        return githubReleaseRedirect("9.9.9");
       }),
     );
     await service.checkForUpgrade(
@@ -177,7 +186,7 @@ describe("DefaultUpgradeService", () => {
     expect(receivedOptions?.timeoutMs).toBeUndefined();
   });
 
-  test("checkForUpgrade returns undefined when fetch fails", async () => {
+  test("checkForUpgrade reports failed when fetch fails", async () => {
     const service = new DefaultUpgradeService(
       getConfig({
         githubRelease: { owner: "flowscripter", repo: "example-cli", assetPattern: "x" },
@@ -193,7 +202,30 @@ describe("DefaultUpgradeService", () => {
       SupportedArch.X64,
       InstallMethod.GITHUB_RELEASE,
     );
-    expect(result).toBeUndefined();
+    expect(result.status).toEqual("failed");
+    if (result.status !== "failed") throw new Error("expected failed");
+    expect(result.error.message).toContain("network error");
+  });
+
+  test("checkForUpgrade reports failed when GitHub does not respond with a redirect", async () => {
+    const service = new DefaultUpgradeService(
+      getConfig({
+        githubRelease: { owner: "flowscripter", repo: "example-cli", assetPattern: "x" },
+      }),
+      getCLIConfig(),
+    );
+    service.setDependencies(
+      undefined,
+      getFetchService(() => new Response(null, { status: 404 })),
+    );
+    const result = await service.checkForUpgrade(
+      SupportedOs.LINUX,
+      SupportedArch.X64,
+      InstallMethod.GITHUB_RELEASE,
+    );
+    expect(result.status).toEqual("failed");
+    if (result.status !== "failed") throw new Error("expected failed");
+    expect(result.error.message).toContain("404");
   });
 
   test("checkForUpgrade resolves latest homebrew version from tap formula file", async () => {
@@ -215,7 +247,8 @@ describe("DefaultUpgradeService", () => {
       SupportedArch.ARM64,
       InstallMethod.HOMEBREW,
     );
-    expect(result?.latestVersion).toEqual("9.9.9");
+    if (result.status !== "checked") throw new Error(`expected "checked", got ${result.status}`);
+    expect(result.latestVersion).toEqual("9.9.9");
   });
 
   test("upgrade returns error when no location configured", async () => {
@@ -234,7 +267,7 @@ describe("DefaultUpgradeService", () => {
     );
     service.setDependencies(
       undefined,
-      getFetchService(() => new Response(JSON.stringify({ tag_name: "v9.9.9" }), { status: 200 })),
+      getFetchService(() => githubReleaseRedirect("9.9.9")),
     );
     const result = await service.upgrade(
       SupportedOs.LINUX,
@@ -300,7 +333,7 @@ describe("DefaultUpgradeService", () => {
       undefined,
       getFetchService(() => {
         checkCount++;
-        return new Response(JSON.stringify({ tag_name: "v9.9.9" }), { status: 200 });
+        return githubReleaseRedirect("9.9.9");
       }),
     );
 
@@ -312,7 +345,7 @@ describe("DefaultUpgradeService", () => {
     expect(checkCount).toEqual(1);
   });
 
-  test("getUpgradeCheckResult resolves undefined if the cached check exceeds VERSION_CHECK_TIMEOUT_MS", async () => {
+  test("getUpgradeCheckResult resolves pending if the cached check exceeds VERSION_CHECK_TIMEOUT_MS", async () => {
     const service = new DefaultUpgradeService(
       getConfig({
         githubRelease: { owner: "flowscripter", repo: "example-cli", assetPattern: "x" },
@@ -325,10 +358,10 @@ describe("DefaultUpgradeService", () => {
     );
 
     const result = await service.getUpgradeCheckResult();
-    expect(result).toBeUndefined();
+    expect(result).toEqual({ status: "pending" });
   });
 
-  test("a transient timeout on an opportunistic check does not poison a later deliberate wait", async () => {
+  test("a transient failure on an opportunistic check does not poison a later deliberate wait", async () => {
     let callCount = 0;
     const service = new DefaultUpgradeService(
       getConfig({
@@ -340,23 +373,25 @@ describe("DefaultUpgradeService", () => {
       undefined,
       getFetchService(() => {
         callCount++;
-        // first call (simulating the opportunistic startup check) fails as if its own
-        // internal timeoutMs fired; subsequent calls resolve immediately.
+        // first call (simulating the opportunistic startup check) fails; subsequent calls
+        // resolve immediately.
         if (callCount === 1) {
-          throw new Error("simulated fetch timeout");
+          throw new Error("simulated fetch failure");
         }
-        return new Response(JSON.stringify({ tag_name: "v9.9.9" }), { status: 200 });
+        return githubReleaseRedirect("9.9.9");
       }),
     );
 
     // opportunistic, non-blocking call - its underlying fetch fails immediately.
     const opportunistic = await service.getUpgradeCheckResult();
-    expect(opportunistic).toBeUndefined();
+    expect(opportunistic.status).toEqual("failed");
 
     // a later, deliberate blocking call (e.g. the `upgrade` command) must get a fresh attempt
-    // rather than reusing the earlier timed-out promise forever.
+    // rather than reusing the earlier failed promise forever.
     const deliberate = await service.getUpgradeCheckResult(true);
-    expect(deliberate?.latestVersion).toEqual("9.9.9");
+    if (deliberate.status !== "checked")
+      throw new Error(`expected "checked", got ${deliberate.status}`);
+    expect(deliberate.latestVersion).toEqual("9.9.9");
     expect(callCount).toEqual(2);
   });
 
@@ -373,7 +408,7 @@ describe("DefaultUpgradeService", () => {
         () =>
           new Promise((resolve) =>
             setTimeout(
-              () => resolve(new Response(JSON.stringify({ tag_name: "v9.9.9" }), { status: 200 })),
+              () => resolve(githubReleaseRedirect("9.9.9")),
               VERSION_CHECK_TIMEOUT_MS + 50,
             ),
           ),
@@ -381,7 +416,8 @@ describe("DefaultUpgradeService", () => {
     );
 
     const result = await service.getUpgradeCheckResult(true);
-    expect(result?.latestVersion).toEqual("9.9.9");
+    if (result.status !== "checked") throw new Error(`expected "checked", got ${result.status}`);
+    expect(result.latestVersion).toEqual("9.9.9");
   });
 
   test("upgrade bypasses the cached check when an override is passed", async () => {

--- a/tests/service/upgrade/UpgradeServiceProvider.test.ts
+++ b/tests/service/upgrade/UpgradeServiceProvider.test.ts
@@ -228,7 +228,7 @@ describe("UpgradeServiceProvider", () => {
       error: () => Promise.resolve(),
     });
 
-    // No upgrade location configured, so checkForUpgrade resolves undefined and nothing is printed.
+    // No upgrade location configured, so checkForUpgrade resolves "unsupported" and nothing is printed.
     await provider.initService(context);
     expect(printed).toEqual("");
   });

--- a/tests/service/upgrade/command/UpgradeSubCommand.test.ts
+++ b/tests/service/upgrade/command/UpgradeSubCommand.test.ts
@@ -12,7 +12,7 @@ import type DefaultUpgradeService from "../../../../src/service/upgrade/DefaultU
 import { getCLIConfig } from "../../../fixtures/CLIConfig.ts";
 
 function getUpgradeService(
-  checkResult: UpgradeCheckResult | undefined,
+  checkResult: UpgradeCheckResult,
   upgradeResult?: UpgradeResult,
 ): DefaultUpgradeService {
   return {
@@ -40,7 +40,7 @@ function getContext(): { context: DefaultContext; messages: { info: string[]; er
 
 describe("UpgradeSubCommand", () => {
   test("prints error when no upgrade location configured", async () => {
-    const command = new UpgradeSubCommand(getUpgradeService(undefined));
+    const command = new UpgradeSubCommand(getUpgradeService({ status: "unsupported" }));
     const { context, messages } = getContext();
 
     await command.execute(context, {});
@@ -48,8 +48,20 @@ describe("UpgradeSubCommand", () => {
     expect(messages.error[0]).toContain("No upgrade location is configured");
   });
 
+  test("prints error when the check failed", async () => {
+    const command = new UpgradeSubCommand(
+      getUpgradeService({ status: "failed", error: new Error("network error") }),
+    );
+    const { context, messages } = getContext();
+
+    await command.execute(context, {});
+
+    expect(messages.error[0]).toContain("Failed to check for updates: network error");
+  });
+
   test("prints already up to date when no update available", async () => {
     const checkResult: UpgradeCheckResult = {
+      status: "checked",
       currentVersion: "1.0.0",
       latestVersion: "1.0.0",
       updateAvailable: false,
@@ -67,6 +79,7 @@ describe("UpgradeSubCommand", () => {
 
   test("prints upgraded message on success", async () => {
     const checkResult: UpgradeCheckResult = {
+      status: "checked",
       currentVersion: "1.0.0",
       latestVersion: "2.0.0",
       updateAvailable: true,
@@ -85,6 +98,7 @@ describe("UpgradeSubCommand", () => {
 
   test("prints error when upgrade fails", async () => {
     const checkResult: UpgradeCheckResult = {
+      status: "checked",
       currentVersion: "1.0.0",
       latestVersion: "2.0.0",
       updateAvailable: true,


### PR DESCRIPTION
## Summary
Implements https://github.com/flowscripter/dynamic-cli-framework-api/pull/10's typed `CompletedUpgradeCheckResult`/`UpgradeCheckResult` in `DefaultUpgradeService`, and fixes the recurring "No upgrade location is configured" failure that was actually a rate-limited/failed network check being misreported as an unsupported platform.

## Changes
- `DefaultUpgradeService`: `checkForUpgrade()` returns `{status: "checked"|"unsupported"|"failed"}`; `getUpgradeCheckResult()` additionally returns `{status: "pending"}` from its non-blocking bounded-wait path. Internal `#getLatestGithubReleaseVersion`/`#getLatestHomebrewVersion`/`#getLatestWingetVersion` now return a `VersionLookupResult` (`{ok: true, version}` | `{ok: false, error}`) so the real failure reason propagates all the way up instead of being discarded.
- GitHub release version check switched from `GET api.github.com/repos/{owner}/{repo}/releases/latest` (JSON, 60 req/hour/IP unauthenticated rate limit - easily exhausted by CI runners sharing an IP pool) to `GET github.com/{owner}/{repo}/releases/latest` with `redirect: "manual"`, parsing the version out of the `Location` header. This is the same non-API host already used for the actual asset download.
- `UpgradeSubCommand`: reports the real error message for a `"failed"` check (`Failed to check for updates: {reason}. Please try again later.`) instead of the generic unsupported-platform message, which is now reserved for the genuine `"unsupported"` case.
- `VersionCommand`/`BannerServiceProvider`: unchanged opportunistic behavior - both simply narrow on `status === "checked"` and stay silent otherwise.
- `UpgradeServiceProvider`'s auto-upgrade path: debug-logs a `"failed"` check's reason instead of silently discarding it.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `bun test` - 761 pass, 0 fail
- [x] `oxlint`/`oxfmt --check` clean

## Depends on
https://github.com/flowscripter/dynamic-cli-framework-api/pull/10 (must merge/release first)