### PR TITLE
fix: append trailing newline to completion install printer messages

### DIFF
--- a/src/service/completion/CompletionServiceProvider.ts
+++ b/src/service/completion/CompletionServiceProvider.ts
@@ -136,7 +136,7 @@ export default class CompletionServiceProvider implements ServiceProvider {
       if (context.doesServiceExist(PRINTER_SERVICE_ID)) {
         const printerService = context.getServiceById(PRINTER_SERVICE_ID) as PrinterService;
         await printerService.error(
-          `Failed to install completion: ${(error as Error).message}`,
+          `Failed to install completion: ${(error as Error).message}\n`,
           Icon.FAILURE,
         );
       }
@@ -194,7 +194,7 @@ export default class CompletionServiceProvider implements ServiceProvider {
     if (context.doesServiceExist(PRINTER_SERVICE_ID)) {
       const printerService = context.getServiceById(PRINTER_SERVICE_ID) as PrinterService;
       await printerService.info(
-        `Shell completion installed for ${shellType}. Restart your shell or run 'source ${configPath}' to activate.`,
+        `Shell completion installed for ${shellType}. Restart your shell or run 'source ${configPath}' to activate.\n`,
         Icon.SUCCESS,
       );
     }


### PR DESCRIPTION
## Summary
- `CompletionServiceProvider#installCompletion` built its success message (`Shell completion installed for ...`) and its failure message (`Failed to install completion: ...`) without a trailing `\n`.
- `DefaultPrinterService` writes messages verbatim without appending a line terminator, so every other call site in the codebase already includes a trailing `\n` (confirmed by auditing all `printerService.info/warn/error/debug` call sites in `src/`). These two were the only ones missing it.
- Symptom: after installing shell completion interactively, the next line of output (e.g. "No command specified") gets glued onto the end of "...activate." with no line break.

## Test plan
- [x] Audited all `printerService.info/warn/error/debug(...)` call sites in `src/` for missing trailing newlines - only the two in `CompletionServiceProvider.ts` were affected.
- [x] `bunx oxlint` on the changed file - clean.
- [ ] `bun test` has pre-existing unrelated failures (stale linked `@flowscripter/dynamic-cli-framework-api` package causing `Export named 'ValueTypeName' not found` in 5 completion test files) - not caused by this change.