### PR TITLE
chore: bump dynamic-plugin-framework to 2.0.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@flowscripter/dynamic-cli-framework",
       "dependencies": {
         "@flowscripter/dynamic-cli-framework-api": "^2.0.0",
-        "@flowscripter/dynamic-plugin-framework": "2.0.0",
+        "@flowscripter/dynamic-plugin-framework": "2.0.2",
         "emphasize": "^7.0.0",
         "fastest-levenshtein": "^1.0.16",
         "figlet": "^1.11.0",
@@ -31,7 +31,7 @@
   "packages": {
     "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@2.0.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-jeSfXanm+RED9zKSxStOJYmDRi3t7bAaDNSQxI+KhraUMb0iTt+TiWPmDZyBN/Bc76hDX9W/lqN7041OALl2pA=="],
 
-    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@2.0.0", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-LPq4JXqsWttvNgE7Z5fim3h78xfeF/754gL7yI4PMjxfIvAZeyJhqsUElXOMEzNIrY9bXTqVWQJBpKO0+Vl61A=="],
+    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@2.0.2", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-So26Z9TsB62zby8d6OMxoULTJ8hrTF1gZAVVHDfpg6Nm76wsOTSImEoOIRYG4OKM08n8908n+E1ySCrKsN0sCg=="],
 
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.57.0", "", { "os": "android", "cpu": "arm" }, "sha512-qVBsEO+KugOsCmUHcO8iqNnqc65p7PCKpCs8M66mPZ+Ri+CWbcpoQOEJBg2OTu03+0qu++NK1jj6IzvQVs0Sig=="],
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@flowscripter/dynamic-cli-framework-api": "^2.0.0",
-    "@flowscripter/dynamic-plugin-framework": "2.0.0",
+    "@flowscripter/dynamic-plugin-framework": "2.0.2",
     "emphasize": "^7.0.0",
     "fastest-levenshtein": "^1.0.16",
     "figlet": "^1.11.0",


### PR DESCRIPTION
## Summary
- Bumps \`@flowscripter/dynamic-plugin-framework\` to \`2.0.2\`, which fixes \`plugin:add\` hanging when the underlying \`bun add\`/\`npm install\` needs an interactive prompt (missing \`stdin: "inherit"\` on the spawned child process). See flowscripter/dynamic-plugin-framework#102.

## Test plan
- [x] \`bun test\` — 761 pass, 0 fail
- [x] \`tsc -p tsconfig.build.json --noEmit\` — clean
- [x] \`oxlint .\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvxRNHoMxUCQwEcuvr8h7G