### PR TITLE
fix: print upgrade hint on same line as version in banner

### DIFF
--- a/src/service/banner/BannerServiceProvider.ts
+++ b/src/service/banner/BannerServiceProvider.ts
@@ -68,18 +68,15 @@ export default class BannerServiceProvider implements ServiceProvider {
       await printerService.info(`  ${printerService.primary(cliConfig.description)}\n`);
     }
     if (cliConfig.version.length > 0) {
-      await printerService.info(`  ${printerService.secondary("version: " + cliConfig.version)}\n`);
-    }
-    if (context.doesServiceExist(UPGRADE_SERVICE_ID)) {
-      const upgradeService = context.getServiceById(UPGRADE_SERVICE_ID) as UpgradeService;
-      const result = await upgradeService.getUpgradeCheckResult();
-      if (result.status === "checked" && result.updateAvailable) {
-        await printerService.info(
-          `  ${printerService.secondary(
-            `(${result.latestVersion} available, run '${cliConfig.name} upgrade')`,
-          )}\n`,
-        );
+      let versionLine = "version: " + cliConfig.version;
+      if (context.doesServiceExist(UPGRADE_SERVICE_ID)) {
+        const upgradeService = context.getServiceById(UPGRADE_SERVICE_ID) as UpgradeService;
+        const result = await upgradeService.getUpgradeCheckResult();
+        if (result.status === "checked" && result.updateAvailable) {
+          versionLine += ` (${result.latestVersion} available, run '${cliConfig.name} upgrade')`;
+        }
       }
+      await printerService.info(`  ${printerService.secondary(versionLine)}\n`);
     }
     if (this.#configurationServiceProvider) {
       const configLocation = this.#configurationServiceProvider.configLocation;

--- a/tests/service/banner/BannerServiceProvider.test.ts
+++ b/tests/service/banner/BannerServiceProvider.test.ts
@@ -118,6 +118,8 @@ describe("BannerServiceProvider tests", () => {
     const bannerServiceProvider = new BannerServiceProvider(100);
     await bannerServiceProvider.initService(context);
 
-    expect(dummyStderr.getString()).toContain("(9.9.9 available, run 'foo upgrade')");
+    expect(dummyStderr.getString()).toContain(
+      "version: foobar (9.9.9 available, run 'foo upgrade')",
+    );
   });
 });


### PR DESCRIPTION
## Summary

The startup banner printed the "upgrade available" hint on its own line below the version line:

```
  version: 1.7.0
  (1.8.1 available, run 'example-cli upgrade')
```

`BannerServiceProvider.initService()` built the version line and the upgrade hint as two separate `printerService.info()` calls. This change builds a single version-line string, appending the upgrade hint (when present) before printing it once, so the output reads:

```
  version: 1.7.0 (1.8.1 available, run 'example-cli upgrade')
```

This matches the format `VersionCommand` already used for the `version` command output.

## Test plan

- [x] Updated `tests/service/banner/BannerServiceProvider.test.ts` to assert the combined single-line format
- [x] `bun test` - 761 pass, 0 fail
- [x] `oxlint index.ts src/ tests/` - clean
- [x] `oxfmt --check index.ts src/ tests/` - clean

Refs #141

<!-- flowscripter-agent:v1 -->