### PR TITLE
fix: remove upgrade hint from version command output

### DIFF
--- a/src/command/VersionCommand.ts
+++ b/src/command/VersionCommand.ts
@@ -2,8 +2,6 @@ import type { Context } from "@flowscripter/dynamic-cli-framework-api";
 import type { GlobalCommand } from "@flowscripter/dynamic-cli-framework-api";
 import type { PrinterService } from "@flowscripter/dynamic-cli-framework-api";
 import { PRINTER_SERVICE_ID } from "@flowscripter/dynamic-cli-framework-api";
-import { UPGRADE_SERVICE_ID } from "@flowscripter/dynamic-cli-framework-api";
-import type { UpgradeService } from "@flowscripter/dynamic-cli-framework-api";
 
 /**
  * Implementation of a {@link GlobalCommand} which outputs the version of the CLI.
@@ -16,15 +14,6 @@ export default class VersionCommand implements GlobalCommand {
   public async execute(context: Context): Promise<void> {
     const printerService = context.getServiceById(PRINTER_SERVICE_ID) as PrinterService;
 
-    let line = context.cliConfig.version;
-    if (context.doesServiceExist(UPGRADE_SERVICE_ID)) {
-      const upgradeService = context.getServiceById(UPGRADE_SERVICE_ID) as UpgradeService;
-      const result = await upgradeService.getUpgradeCheckResult();
-      if (result.status === "checked" && result.updateAvailable) {
-        line += ` (${result.latestVersion} available, run '${context.cliConfig.name} upgrade')`;
-      }
-    }
-
-    await printerService.print(`${line}\n`);
+    await printerService.print(`${context.cliConfig.version}\n`);
   }
 }

--- a/tests/command/VersionCommand.test.ts
+++ b/tests/command/VersionCommand.test.ts
@@ -35,7 +35,7 @@ describe("VersionCommand tests", () => {
     expectStringEquals(dummyStdout.getString(), "foobar\n");
   });
 
-  test("Version shows available upgrade when UpgradeService reports one", async () => {
+  test("Version does not show upgrade hint even when UpgradeService reports one available", async () => {
     const dummyStdout = new StreamString();
     const dummyStderr = new StreamString();
     const printer = new DefaultPrinterService(
@@ -66,7 +66,7 @@ describe("VersionCommand tests", () => {
 
     await versionCommand.execute(context);
 
-    expectStringEquals(dummyStdout.getString(), "foobar (9.9.9 available, run 'foo upgrade')\n");
+    expectStringEquals(dummyStdout.getString(), "foobar\n");
   });
 
   test("Version omits upgrade line when no update available", async () => {


### PR DESCRIPTION
## Summary

`VersionCommand` independently queried `UpgradeService` and appended an
upgrade-availability hint (e.g. `1.7.0 (1.8.1 available, run 'example-cli
upgrade')`) to its output. This removes that logic so `version` prints only
the version number. The startup banner (`BannerServiceProvider`) has its own
separate implementation of the upgrade hint and is unaffected by this change.

## Test plan

- [x] `bun test` (761 tests pass)
- [x] `npx oxlint index.ts src/ tests/`
- [x] `npx oxfmt --check index.ts src/ tests/`
- [x] Updated `tests/command/VersionCommand.test.ts` to assert plain output
      even when an upgrade is available

Refs #142

<!-- flowscripter-agent:v1 -->