### PR TITLE
fix: avoid ETXTBSY on upgrade and correct macOS arch label

### DIFF
--- a/src/service/upgrade/DefaultUpgradeService.ts
+++ b/src/service/upgrade/DefaultUpgradeService.ts
@@ -1,7 +1,7 @@
 import process from "node:process";
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, rename, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import type {
   CLIConfig,
   FetchService,
@@ -413,8 +413,10 @@ export default class DefaultUpgradeService implements UpgradeService {
 
   async #upgradeViaGithubRelease(os: SupportedOs, arch: SupportedArch): Promise<void> {
     const { owner, repo, assetPattern } = this.#config.githubRelease!;
+    // macOS release assets use "aarch64" rather than "arm64" for the arm64 build; x64 (including
+    // Intel Macs) always uses "x64" regardless of os.
     const archLabel =
-      os === SupportedOs.MACOS ? "aarch64" : arch === SupportedArch.X64 ? "x64" : "arm64";
+      arch === SupportedArch.X64 ? "x64" : os === SupportedOs.MACOS ? "aarch64" : "arm64";
     const assetName = assetPattern.replace("{os}", OS_LABELS[os]).replace("{arch}", archLabel);
     const url = `https://github.com/${owner}/${repo}/releases/latest/download/${assetName}`;
 
@@ -446,6 +448,16 @@ export default class DefaultUpgradeService implements UpgradeService {
       }
       const extractedBinary = join(tmpDir, `${this.#cliConfig.name}.exe`);
       const oldPath = `${currentExecutable}.old.exe`;
+
+      // Best-effort cleanup of a stale "<exe>.old.exe" left behind by a *previous* upgrade run.
+      // Windows won't let us delete the just-renamed-aside exe while this process still has it
+      // open/mapped - that can only happen once we're no longer holding it, i.e. at the start of
+      // the NEXT invocation, before we move today's running exe aside. Ignore failures: the file
+      // may not exist, or may still be locked (e.g. another instance still running).
+      await this.#spawnService!.spawn(["cmd", "/c", "del", "/f", "/q", oldPath], {
+        mode: "ignore",
+      });
+
       const moveResult = await this.#spawnService!.spawn(
         ["cmd", "/c", "move", "/y", currentExecutable, oldPath],
         { mode: "ignore" },
@@ -471,8 +483,22 @@ export default class DefaultUpgradeService implements UpgradeService {
         throw new Error("Failed to extract release archive");
       }
       const extractedBinary = join(tmpDir, this.#cliConfig.name);
-      await Bun.write(currentExecutable, Bun.file(extractedBinary));
-      await this.#spawnService!.spawn(["chmod", "+x", currentExecutable], { mode: "ignore" });
+
+      // Extract into a staging file in the SAME directory as the running executable (not
+      // os.tmpdir(), which may be a different filesystem/mount), then atomically rename it over
+      // currentExecutable. This avoids ETXTBSY: the kernel refuses to open-for-write the inode
+      // mapped as a running process's text segment, but rename() only swaps the directory entry
+      // to point at a different inode - the running process keeps executing from its original,
+      // now-unlinked-but-still-open inode until it next execs/restarts.
+      const stagingDir = await mkdtemp(join(dirname(currentExecutable), ".upgrade-"));
+      try {
+        const stagingBinary = join(stagingDir, this.#cliConfig.name);
+        await Bun.write(stagingBinary, Bun.file(extractedBinary));
+        await this.#spawnService!.spawn(["chmod", "+x", stagingBinary], { mode: "ignore" });
+        await rename(stagingBinary, currentExecutable);
+      } finally {
+        await rm(stagingDir, { recursive: true, force: true });
+      }
     }
   }
 }

--- a/tests/service/upgrade/DefaultUpgradeService.test.ts
+++ b/tests/service/upgrade/DefaultUpgradeService.test.ts
@@ -1,5 +1,9 @@
 import process from "node:process";
-import { describe, expect, test } from "bun:test";
+import { rmSync, writeFileSync } from "node:fs";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { InstallMethod, SupportedArch, SupportedOs } from "@flowscripter/dynamic-cli-framework-api";
 import type {
   FetchOptions,
@@ -15,8 +19,8 @@ import type { UpgradeLocationsConfig } from "../../../src/service/upgrade/Upgrad
 import { getCLIConfig as getFixtureCLIConfig } from "../../fixtures/CLIConfig.ts";
 
 // The shared fixture uses a non-semver "foobar" version; version comparison tests need a real one.
-function getCLIConfig(): CLIConfig {
-  return { ...getFixtureCLIConfig(), version: "1.0.0" };
+function getCLIConfig(name?: string): CLIConfig {
+  return { ...getFixtureCLIConfig(name), version: "1.0.0" };
 }
 
 function getConfig(overrides: Partial<UpgradeLocationsConfig> = {}): UpgradeLocationsConfig {
@@ -49,6 +53,23 @@ function githubReleaseRedirect(version: string): Response {
   return new Response(null, {
     status: 302,
     headers: { location: `https://github.com/flowscripter/example-cli/releases/tag/v${version}` },
+  });
+}
+
+// upgrade() with an override first calls checkForUpgrade() (a redirect response resolving the
+// latest version tag), then separately downloads the release asset itself (a 200 with a body).
+// Track a URL callback so tests can inspect which asset was requested.
+function getGithubReleaseFetchService(
+  version: string,
+  onAssetUrl?: (url: string) => void,
+): FetchService {
+  return getFetchService((input) => {
+    const url = input.toString();
+    if (url.endsWith("/releases/latest")) {
+      return githubReleaseRedirect(version);
+    }
+    onAssetUrl?.(url);
+    return new Response("new binary content", { status: 200 });
   });
 }
 
@@ -446,5 +467,222 @@ describe("DefaultUpgradeService", () => {
     );
     expect(result.ok).toBe(true);
     expect(result.newVersion).toEqual("9.9.9");
+  });
+
+  describe("upgrade via GitHub release", () => {
+    let workDir: string;
+    let currentExecutable: string;
+    let originalExecPath: string;
+
+    beforeEach(async () => {
+      workDir = await mkdtemp(join(tmpdir(), "dcf-upgrade-test-"));
+      currentExecutable = join(workDir, "example-cli");
+      await writeFile(currentExecutable, "old binary content");
+      originalExecPath = process.execPath;
+      // #upgradeViaGithubRelease reads process.execPath directly (it must always operate on the
+      // real running executable in production); override it for the duration of the test so the
+      // fix's fs operations run against a disposable fixture file instead of the real test
+      // runner binary.
+      Object.defineProperty(process, "execPath", { value: currentExecutable, configurable: true });
+    });
+
+    afterEach(async () => {
+      Object.defineProperty(process, "execPath", { value: originalExecPath, configurable: true });
+      await rm(workDir, { recursive: true, force: true });
+    });
+
+    test("upgrade via GitHub release on Linux extracts to a staging file and renames it into place, avoiding ETXTBSY", async () => {
+      const spawnedCommands: ReadonlyArray<string>[] = [];
+      let stagingBinaryChmodPath: string | undefined;
+      const service = new DefaultUpgradeService(
+        getConfig({
+          githubRelease: {
+            owner: "flowscripter",
+            repo: "example-cli",
+            assetPattern: "example-cli_{os}_{arch}.zip",
+          },
+        }),
+        getCLIConfig("example-cli"),
+      );
+      service.setDependencies(
+        getSpawnService((command) => {
+          spawnedCommands.push(command);
+          if (command[0] === "unzip") {
+            // Simulate the archive extraction step: `unzip -o <archive> -d <tmpDir>` produces
+            // an extracted binary at <tmpDir>/example-cli.
+            const tmpDir = command[4] as string;
+            writeFileSync(join(tmpDir, "example-cli"), "new binary content");
+          }
+          if (command[0] === "chmod") {
+            stagingBinaryChmodPath = command[2];
+          }
+          return { ok: true, exitCode: 0 };
+        }),
+        getGithubReleaseFetchService("9.9.9"),
+      );
+
+      const result = await service.upgrade(
+        SupportedOs.LINUX,
+        SupportedArch.X64,
+        InstallMethod.GITHUB_RELEASE,
+      );
+
+      expect(result.ok).toBe(true);
+      // The final content at currentExecutable must be the new binary - proving a real
+      // replacement happened (via rename), not a no-op.
+      expect(await readFile(currentExecutable, "utf8")).toEqual("new binary content");
+      // chmod +x must run against a staging path in the SAME directory as currentExecutable
+      // (same filesystem, required for rename() to be atomic), not os.tmpdir().
+      expect(stagingBinaryChmodPath).toBeDefined();
+      expect(join(stagingBinaryChmodPath!, "..")).not.toEqual(tmpdir());
+      expect(stagingBinaryChmodPath!.startsWith(workDir)).toBe(true);
+      // No leftover staging directory (created via mkdtemp) should remain.
+      const stagingDirEntries = spawnedCommands.filter((c) => c[0] === "chmod").map((c) => c[2]);
+      expect(stagingDirEntries.length).toEqual(1);
+    });
+
+    test("upgrade via GitHub release requests the 'aarch64' asset label for macOS arm64", async () => {
+      let requestedUrl: string | undefined;
+      const service = new DefaultUpgradeService(
+        getConfig({
+          githubRelease: {
+            owner: "flowscripter",
+            repo: "example-cli",
+            assetPattern: "example-cli_{os}_{arch}.zip",
+          },
+        }),
+        getCLIConfig("example-cli"),
+      );
+      service.setDependencies(
+        getSpawnService((command) => {
+          if (command[0] === "unzip") {
+            const tmpDir = command[4] as string;
+            writeFileSync(join(tmpDir, "example-cli"), "new binary content");
+          }
+          return { ok: true, exitCode: 0 };
+        }),
+        getGithubReleaseFetchService("9.9.9", (url) => {
+          requestedUrl = url;
+        }),
+      );
+
+      const result = await service.upgrade(
+        SupportedOs.MACOS,
+        SupportedArch.ARM64,
+        InstallMethod.GITHUB_RELEASE,
+      );
+      expect(result.ok).toBe(true);
+      expect(requestedUrl).toContain("example-cli_MacOS_aarch64.zip");
+    });
+
+    test("upgrade via GitHub release requests the 'x64' asset label for macOS x64 (Intel)", async () => {
+      let requestedUrl: string | undefined;
+      const service = new DefaultUpgradeService(
+        getConfig({
+          supportedPlatforms: [{ os: SupportedOs.MACOS, arch: SupportedArch.X64 }],
+          githubRelease: {
+            owner: "flowscripter",
+            repo: "example-cli",
+            assetPattern: "example-cli_{os}_{arch}.zip",
+          },
+        }),
+        getCLIConfig("example-cli"),
+      );
+      service.setDependencies(
+        getSpawnService((command) => {
+          if (command[0] === "unzip") {
+            const tmpDir = command[4] as string;
+            writeFileSync(join(tmpDir, "example-cli"), "new binary content");
+          }
+          return { ok: true, exitCode: 0 };
+        }),
+        getGithubReleaseFetchService("9.9.9", (url) => {
+          requestedUrl = url;
+        }),
+      );
+
+      const result = await service.upgrade(
+        SupportedOs.MACOS,
+        SupportedArch.X64,
+        InstallMethod.GITHUB_RELEASE,
+      );
+      expect(result.ok).toBe(true);
+      expect(requestedUrl).toContain("example-cli_MacOS_x64.zip");
+    });
+
+    test("upgrade via GitHub release requests the 'arm64' asset label for Linux arm64", async () => {
+      let requestedUrl: string | undefined;
+      const service = new DefaultUpgradeService(
+        getConfig({
+          githubRelease: {
+            owner: "flowscripter",
+            repo: "example-cli",
+            assetPattern: "example-cli_{os}_{arch}.zip",
+          },
+        }),
+        getCLIConfig("example-cli"),
+      );
+      service.setDependencies(
+        getSpawnService((command) => {
+          if (command[0] === "unzip") {
+            const tmpDir = command[4] as string;
+            writeFileSync(join(tmpDir, "example-cli"), "new binary content");
+          }
+          return { ok: true, exitCode: 0 };
+        }),
+        getGithubReleaseFetchService("9.9.9", (url) => {
+          requestedUrl = url;
+        }),
+      );
+
+      const result = await service.upgrade(
+        SupportedOs.LINUX,
+        SupportedArch.ARM64,
+        InstallMethod.GITHUB_RELEASE,
+      );
+      expect(result.ok).toBe(true);
+      expect(requestedUrl).toContain("example-cli_Linux_arm64.zip");
+    });
+
+    test("upgrade via GitHub release on Windows deletes any stale '.old.exe' before moving the current exe aside", async () => {
+      const spawnedCommands: ReadonlyArray<string>[] = [];
+      const oldPath = `${currentExecutable}.old.exe`;
+      // Simulate a stale leftover from a previous upgrade run.
+      await writeFile(oldPath, "stale leftover from a previous upgrade");
+
+      const service = new DefaultUpgradeService(
+        getConfig({
+          githubRelease: {
+            owner: "flowscripter",
+            repo: "example-cli",
+            assetPattern: "example-cli_{os}_{arch}.zip",
+          },
+        }),
+        getCLIConfig("example-cli"),
+      );
+      service.setDependencies(
+        getSpawnService((command) => {
+          spawnedCommands.push(command);
+          if (command[0] === "cmd" && command[2] === "del") {
+            rmSync(oldPath, { force: true });
+          }
+          return { ok: true, exitCode: 0 };
+        }),
+        getGithubReleaseFetchService("9.9.9"),
+      );
+
+      const result = await service.upgrade(
+        SupportedOs.WINDOWS,
+        SupportedArch.X64,
+        InstallMethod.GITHUB_RELEASE,
+      );
+
+      expect(result.ok).toBe(true);
+      const delIndex = spawnedCommands.findIndex((c) => c[0] === "cmd" && c[2] === "del");
+      const moveIndex = spawnedCommands.findIndex((c) => c[0] === "cmd" && c[2] === "move");
+      expect(delIndex).toBeGreaterThanOrEqual(0);
+      expect(moveIndex).toBeGreaterThan(delIndex);
+      expect(spawnedCommands[delIndex]).toEqual(["cmd", "/c", "del", "/f", "/q", oldPath]);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Implements the fixes agreed on in #143.

### 1. ETXTBSY on Linux/macOS upgrade (root cause)

`DefaultUpgradeService.#upgradeViaGithubRelease()` wrote the downloaded binary directly into `process.execPath` via `Bun.write(currentExecutable, ...)` - opening the currently-running executable's inode for writing. Both Linux and macOS kernels refuse this (`ETXTBSY`, "text file is busy") because that inode is mapped as the running process's text segment. This is a VM-level protection, not a permissions issue - the errno name is a historical artifact of the `exec()`-maps-code-segment era, not a claim that the file is "text" in any other sense.

The kernel only blocks *writing into* the running inode; it does not block unlinking or renaming the directory entry. Fix: extract the new binary into a staging file in the **same directory** as the executable (same filesystem/mount, required for `rename()` to be atomic - `os.tmpdir()` may be a different mount), `chmod +x` it, then `rename()` it onto `currentExecutable`. Rename only swaps the directory entry; the running process keeps executing from its original, now-unlinked-but-still-open inode until it next execs/restarts. No ETXTBSY, and no need to wait for the process to exit.

### 2. Hardcoded macOS arch label

`archLabel` was hardcoded to `"aarch64"` for any `os === SupportedOs.MACOS`, regardless of actual `arch`. An Intel (x64) Mac would request an `aarch64` asset. Now `arch` is checked first: `x64` always maps to `"x64"`; `arm64` maps to `"aarch64"` on macOS (matching existing release asset naming) or `"arm64"` elsewhere.

### 3. Windows stale `<exe>.old.exe` (answering Nick's question)

**Yes, this does leave a stale file behind after the upgrade command completes and the CLI exits.** The existing Windows path moves the running exe to `<exe>.old.exe` (avoiding ETXTBSY-equivalent failures on Windows entirely, since it never writes into the open file - it just renames it aside), then copies the new binary into the vacated original path. That part is fine and unchanged. But nothing ever deletes `<exe>.old.exe` - and it *can't* be deleted during that same run, because this process still holds its own image open under that path.

Fix: at the start of each Windows upgrade run, before moving today's running exe aside, best-effort delete any stale `<exe>.old.exe` left over from a *previous* run (`cmd /c del /f /q`, failure ignored - the file may not exist, or may still be locked if another instance is running). This means a stale file only lingers between one upgrade and the next, not indefinitely, and cleanup requires no scheduled tasks, exit hooks, or waiting on process exit - just reusing the same rename-based approach the code already relies on.

## Test plan

- [x] `bun test` - 766 pass, 0 fail (27 in `DefaultUpgradeService.test.ts`, including new coverage for extract-then-rename on Linux/macOS, arch-label selection across os/arch combinations, and the Windows stale-`.old.exe` cleanup ordering)
- [x] `npx oxlint index.ts src/ tests/` - clean
- [x] `npx oxfmt --check index.ts src/ tests/` - clean
- [x] `npx tsc -p tsconfig.json --noEmit` - clean

Refs #143

<!-- flowscripter-agent:v1 -->