### PR TITLE
fix: don't clear spawned quoted output on error

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@flowscripter/dynamic-cli-framework",
       "dependencies": {
-        "@flowscripter/dynamic-cli-framework-api": "^2.0.0",
+        "@flowscripter/dynamic-cli-framework-api": "^2.1.0",
         "@flowscripter/dynamic-plugin-framework": "2.1.1",
         "emphasize": "^7.0.0",
         "fastest-levenshtein": "^1.0.16",
@@ -29,7 +29,7 @@
     },
   },
   "packages": {
-    "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@2.0.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-jeSfXanm+RED9zKSxStOJYmDRi3t7bAaDNSQxI+KhraUMb0iTt+TiWPmDZyBN/Bc76hDX9W/lqN7041OALl2pA=="],
+    "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@2.1.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-vZ7pIRGlovuje2IG2CF+PCpVxUfvqRNHap5m1Ix1i+p9tAFQNyqKZyeanOy0UlFB+MAkCbBl+gQq9gY7eUcW4w=="],
 
     "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@2.1.1", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-0fHxgPAsb1xrnv3J8YdNtK0eOhTuKzM6J/fU4IYJEj5y8qlj7v1SZIO3+jvN3y8aEgYRxd6B2GAfXKk9WGR2Pg=="],
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "build": "tsc -p tsconfig.build.json"
   },
   "dependencies": {
-    "@flowscripter/dynamic-cli-framework-api": "^2.0.0",
+    "@flowscripter/dynamic-cli-framework-api": "^2.1.0",
     "@flowscripter/dynamic-plugin-framework": "2.1.1",
     "emphasize": "^7.0.0",
     "fastest-levenshtein": "^1.0.16",

--- a/src/service/plugin/SpawnInterfaceAdapter.ts
+++ b/src/service/plugin/SpawnInterfaceAdapter.ts
@@ -57,16 +57,11 @@ export default class SpawnInterfaceAdapter implements SpawnInterface {
     this.#printerService.endMark();
     if (result.ok) {
       await this.#printerService.clearMarked(this.#markMinimumDisplayTimeMs);
-    } else if ("discardMark" in this.#printerService) {
+    } else {
       // Leave the marked/quoted output on screen so the failing command's diagnostic output is
       // visible, but still reset the mark/quote bookkeeping so a subsequent spawn() can start a
       // fresh mark region.
-      //
-      // discardMark() is being promoted to a first-class PrinterService interface method
-      // (flowscripter/dynamic-cli-framework-api#12); once that's released and this repo's
-      // @flowscripter/dynamic-cli-framework-api dependency is bumped, this can call
-      // this.#printerService.discardMark() directly instead of feature-detecting it.
-      (this.#printerService as unknown as { discardMark: () => void }).discardMark();
+      this.#printerService.discardMark();
     }
 
     if (result.ok) {

--- a/src/service/plugin/SpawnInterfaceAdapter.ts
+++ b/src/service/plugin/SpawnInterfaceAdapter.ts
@@ -61,6 +61,11 @@ export default class SpawnInterfaceAdapter implements SpawnInterface {
       // Leave the marked/quoted output on screen so the failing command's diagnostic output is
       // visible, but still reset the mark/quote bookkeeping so a subsequent spawn() can start a
       // fresh mark region.
+      //
+      // discardMark() is being promoted to a first-class PrinterService interface method
+      // (flowscripter/dynamic-cli-framework-api#12); once that's released and this repo's
+      // @flowscripter/dynamic-cli-framework-api dependency is bumped, this can call
+      // this.#printerService.discardMark() directly instead of feature-detecting it.
       (this.#printerService as unknown as { discardMark: () => void }).discardMark();
     }
 

--- a/src/service/plugin/SpawnInterfaceAdapter.ts
+++ b/src/service/plugin/SpawnInterfaceAdapter.ts
@@ -8,8 +8,10 @@ export interface SpawnInterfaceAdapterOptions {
 
 /**
  * Adapts a {@link SpawnService} to dynamic-plugin-framework's {@link SpawnInterface}, wrapping
- * spawned process output in a quoted, marked block via {@link PrinterService} that is cleared
- * again once the process exits (subject to {@link SpawnInterfaceAdapterOptions.markMinimumDisplayTimeMs}).
+ * spawned process output in a quoted, marked block via {@link PrinterService}. On success the
+ * block is cleared once the process exits (subject to
+ * {@link SpawnInterfaceAdapterOptions.markMinimumDisplayTimeMs}); on failure the block is left
+ * on screen so the diagnostic output from the failing command remains visible.
  */
 export default class SpawnInterfaceAdapter implements SpawnInterface {
   readonly #spawnService: SpawnService;
@@ -53,7 +55,14 @@ export default class SpawnInterfaceAdapter implements SpawnInterface {
 
     this.#printerService.endQuote();
     this.#printerService.endMark();
-    await this.#printerService.clearMarked(this.#markMinimumDisplayTimeMs);
+    if (result.ok) {
+      await this.#printerService.clearMarked(this.#markMinimumDisplayTimeMs);
+    } else if ("discardMark" in this.#printerService) {
+      // Leave the marked/quoted output on screen so the failing command's diagnostic output is
+      // visible, but still reset the mark/quote bookkeeping so a subsequent spawn() can start a
+      // fresh mark region.
+      (this.#printerService as unknown as { discardMark: () => void }).discardMark();
+    }
 
     if (result.ok) {
       return { ok: true, exitCode: result.exitCode };

--- a/src/service/printer/DefaultPrinterService.ts
+++ b/src/service/printer/DefaultPrinterService.ts
@@ -312,6 +312,23 @@ export default class DefaultPrinterService implements PrinterService {
     this.#markEndedAt = Date.now();
   }
 
+  /**
+   * Stop tracking rows for the current mark region without erasing them - e.g. when the marked
+   * output should be left on screen (such as a spawned command's output on failure), but the
+   * mark/quote bookkeeping still needs to be reset so a later startMark() doesn't throw.
+   *
+   * Not part of the public PrinterService interface - callers that want to leave marked output
+   * in place should feature-detect it (`"discardMark" in printerService`) since a PrinterService
+   * received via dependency injection is not guaranteed to be a DefaultPrinterService.
+   */
+  public discardMark(): void {
+    if (this.#markedLineCount === undefined) {
+      throw new Error("discardMark() called without a preceding startMark()");
+    }
+    this.#markedLineCount = undefined;
+    this.#markEndedAt = undefined;
+  }
+
   public async clearMarked(minimumDisplayTimeMs = 0): Promise<void> {
     if (this.#markedLineCount === undefined || this.#markEndedAt === undefined) {
       throw new Error("clearMarked() called without a preceding endMark()");

--- a/src/service/printer/DefaultPrinterService.ts
+++ b/src/service/printer/DefaultPrinterService.ts
@@ -316,10 +316,6 @@ export default class DefaultPrinterService implements PrinterService {
    * Stop tracking rows for the current mark region without erasing them - e.g. when the marked
    * output should be left on screen (such as a spawned command's output on failure), but the
    * mark/quote bookkeeping still needs to be reset so a later startMark() doesn't throw.
-   *
-   * Not part of the public PrinterService interface - callers that want to leave marked output
-   * in place should feature-detect it (`"discardMark" in printerService`) since a PrinterService
-   * received via dependency injection is not guaranteed to be a DefaultPrinterService.
    */
   public discardMark(): void {
     if (this.#markedLineCount === undefined) {

--- a/src/service/spawn/DefaultSpawnService.ts
+++ b/src/service/spawn/DefaultSpawnService.ts
@@ -132,9 +132,7 @@ export default class DefaultSpawnService implements SpawnService {
     // These are intentionally not awaited here - they only complete once the child's stdout/
     // stderr streams reach EOF, which can happen slightly after proc.exited resolves. They are
     // awaited below, before returning, so that every onOutput callback (and thus every write it
-    // triggers) is guaranteed to have completed before the caller acts on the result - otherwise
-    // a caller tracking "lines written during this spawn" (e.g. for a subsequent screen clear)
-    // could observe a count that is missing lines still in flight.
+    // triggers) is guaranteed to have completed before the caller acts on the result.
     let pipeStdout: Promise<void> = Promise.resolve();
     let pipeStderr: Promise<void> = Promise.resolve();
     if (mode === "wrapped" && options.onOutput) {

--- a/src/service/spawn/DefaultSpawnService.ts
+++ b/src/service/spawn/DefaultSpawnService.ts
@@ -129,15 +129,24 @@ export default class DefaultSpawnService implements SpawnService {
       await this.#terminate(proc, command);
     });
 
+    // These are intentionally not awaited here - they only complete once the child's stdout/
+    // stderr streams reach EOF, which can happen slightly after proc.exited resolves. They are
+    // awaited below, before returning, so that every onOutput callback (and thus every write it
+    // triggers) is guaranteed to have completed before the caller acts on the result - otherwise
+    // a caller tracking "lines written during this spawn" (e.g. for a subsequent screen clear)
+    // could observe a count that is missing lines still in flight.
+    let pipeStdout: Promise<void> = Promise.resolve();
+    let pipeStderr: Promise<void> = Promise.resolve();
     if (mode === "wrapped" && options.onOutput) {
       const onOutput = options.onOutput;
-      void this.#pipeLines(proc.stdout, "stdout", onOutput);
-      void this.#pipeLines(proc.stderr, "stderr", onOutput);
+      pipeStdout = this.#pipeLines(proc.stdout, "stdout", onOutput);
+      pipeStderr = this.#pipeLines(proc.stderr, "stderr", onOutput);
     }
 
     try {
       if (options.timeoutMs === undefined) {
         const exitCode = await proc.exited;
+        await Promise.all([pipeStdout, pipeStderr]);
         settled = true;
         return exitCode === 0 ? { ok: true, exitCode } : { ok: false, exitCode };
       }
@@ -154,11 +163,13 @@ export default class DefaultSpawnService implements SpawnService {
       if (timedOut) {
         logger.debug(() => `Command '${command.join(" ")}' timed out after ${options.timeoutMs}ms`);
         await this.#terminate(proc, command);
+        await Promise.all([pipeStdout, pipeStderr]);
         settled = true;
         return { ok: false, timedOut: true };
       }
 
       const exitCode = await proc.exited;
+      await Promise.all([pipeStdout, pipeStderr]);
       settled = true;
       return exitCode === 0 ? { ok: true, exitCode } : { ok: false, exitCode };
     } finally {

--- a/tests/service/plugin/SpawnInterfaceAdapter.test.ts
+++ b/tests/service/plugin/SpawnInterfaceAdapter.test.ts
@@ -33,6 +33,9 @@ function getFakePrinterService(): {
       state.calls.push(`clearMarked(${minimumDisplayTimeMs ?? ""})`);
       return Promise.resolve();
     },
+    discardMark: () => {
+      state.calls.push("discardMark");
+    },
     info: (message: string) => {
       state.calls.push("info");
       state.infoMessages.push(message);
@@ -108,5 +111,47 @@ describe("SpawnInterfaceAdapter tests", () => {
     const result = await adapter.spawn(["nonexistent"], { cwd: "/tmp" });
 
     expect(result).toEqual({ ok: false, exitCode: undefined, error });
+  });
+
+  test("does not clear the marked/quoted block on failure, but resets mark bookkeeping", async () => {
+    const { printerService, state } = getFakePrinterService();
+    const spawnService = getFakeSpawnService(
+      [{ line: "some diagnostic output", stream: "stderr" }],
+      { ok: false, exitCode: 1, error: undefined },
+    );
+    const adapter = new SpawnInterfaceAdapter(spawnService, printerService);
+
+    await adapter.spawn(["bun", "add", "foo"], { cwd: "/tmp" });
+
+    expect(state.calls).toEqual([
+      "startQuote()",
+      "startMark",
+      "info",
+      "endQuote",
+      "endMark",
+      "discardMark",
+    ]);
+    expect(state.calls).not.toContain("clearMarked(1000)");
+  });
+
+  test("clears the marked/quoted block on success", async () => {
+    const { printerService, state } = getFakePrinterService();
+    const spawnService = getFakeSpawnService([{ line: "installed ok", stream: "stdout" }], {
+      ok: true,
+      exitCode: 0,
+    });
+    const adapter = new SpawnInterfaceAdapter(spawnService, printerService);
+
+    await adapter.spawn(["bun", "add", "foo"], { cwd: "/tmp" });
+
+    expect(state.calls).toEqual([
+      "startQuote()",
+      "startMark",
+      "info",
+      "endQuote",
+      "endMark",
+      "clearMarked(1000)",
+    ]);
+    expect(state.calls).not.toContain("discardMark");
   });
 });

--- a/tests/service/printer/DefaultPrinterService.test.ts
+++ b/tests/service/printer/DefaultPrinterService.test.ts
@@ -811,4 +811,69 @@ describe("DefaultPrinterService tests", () => {
     await printerService.clearMarked(100);
     expect(Date.now() - start).toBeGreaterThanOrEqual(90);
   });
+
+  test("discardMark() resets mark tracking without writing anything", () => {
+    const dummyStdout = new StreamString();
+    const dummyStderr = new StreamString();
+    const printerService = new DefaultPrinterService(
+      dummyStdout.writableStream,
+      dummyStderr.writableStream,
+      true,
+      true,
+      new TtyTerminal(dummyStdout.writeStream),
+      new TtyTerminal(dummyStderr.writeStream),
+      new TtyStyler(3),
+    );
+    printerService.colorEnabled = false;
+
+    printerService.startMark();
+    printerService.discardMark();
+
+    expect(dummyStderr.getString()).toEqual("");
+    // A fresh startMark() after discardMark() must not throw "already marking".
+    expect(() => printerService.startMark()).not.toThrow();
+  });
+
+  test("discardMark() leaves preceding, non-marked stderr output untouched", async () => {
+    const dummyStdout = new StreamString();
+    const dummyStderr = new StreamString();
+    const printerService = new DefaultPrinterService(
+      dummyStdout.writableStream,
+      dummyStderr.writableStream,
+      true,
+      true,
+      new TtyTerminal(dummyStdout.writeStream),
+      new TtyTerminal(dummyStderr.writeStream),
+      new TtyStyler(3),
+    );
+    printerService.colorEnabled = false;
+
+    await printerService.info("preceding line1\n");
+    await printerService.info("preceding line2\n");
+
+    printerService.startMark();
+    await printerService.info("marked line1\n");
+    printerService.endMark();
+    printerService.discardMark();
+
+    expect(dummyStderr.getString()).toEqual("preceding line1\npreceding line2\nmarked line1\n");
+  });
+
+  test("discardMark() without startMark() throws", () => {
+    const dummyStdout = new StreamString();
+    const dummyStderr = new StreamString();
+    const printerService = new DefaultPrinterService(
+      dummyStdout.writableStream,
+      dummyStderr.writableStream,
+      true,
+      true,
+      new TtyTerminal(dummyStdout.writeStream),
+      new TtyTerminal(dummyStderr.writeStream),
+      new TtyStyler(3),
+    );
+
+    expect(() => printerService.discardMark()).toThrow(
+      "discardMark() called without a preceding startMark()",
+    );
+  });
 });

--- a/tests/service/prompter/DefaultPrompterService.test.ts
+++ b/tests/service/prompter/DefaultPrompterService.test.ts
@@ -107,6 +107,7 @@ function getMockPrinterService(): PrinterService {
     endQuote: () => {},
     startMark: () => {},
     endMark: () => {},
+    discardMark: () => {},
     clearMarked: () => Promise.resolve(),
     stdoutColumns: () => 80,
     stderrColumns: () => 80,

--- a/tests/service/spawn/DefaultSpawnService.test.ts
+++ b/tests/service/spawn/DefaultSpawnService.test.ts
@@ -193,6 +193,27 @@ describe("DefaultSpawnService tests", () => {
     expect(result).toEqual({ ok: false, timedOut: true });
   });
 
+  test("spawn() waits for all buffered output to be delivered via onOutput before resolving", async () => {
+    const service = new DefaultSpawnService();
+    const { printerService } = getFakePrinterService();
+    const { shutdownService } = getFakeShutdownService();
+    service.setDependencies(printerService, shutdownService);
+
+    const lines: Array<{ line: string; stream: "stdout" | "stderr" }> = [];
+    const lineCount = 200;
+    const result = await service.spawn(
+      ["sh", "-c", `for i in $(seq 1 ${lineCount}); do echo line$i; done`],
+      {
+        mode: "wrapped",
+        onOutput: (line, stream) => lines.push({ line, stream }),
+      },
+    );
+
+    expect(result).toEqual({ ok: true, exitCode: 0 });
+    expect(lines.length).toEqual(lineCount);
+    expect(lines[lineCount - 1]).toEqual({ line: `line${lineCount}`, stream: "stdout" });
+  });
+
   test("spawn() with mode ignore discards output and does not touch the printer", async () => {
     const service = new DefaultSpawnService();
     const { printerService, state } = getFakePrinterService();


### PR DESCRIPTION
## Summary

`SpawnInterfaceAdapter.spawn()` wraps a spawned command's output in a quoted, marked block via `PrinterService.startQuote()`/`startMark()`, then unconditionally called `clearMarked()` once the command finished - regardless of whether it succeeded or failed. On failure this erased the diagnostic output the user needs to see (issue example: a failing `bun add` leaves only the banner and the top-level "Execution error" line visible, with all the useful detail about *why* it failed wiped from the screen).

### Fix 1: don't clear on failure

`SpawnInterfaceAdapter.spawn()` now only calls `clearMarked()` when the spawned command succeeded. On failure it instead calls a new `DefaultPrinterService.discardMark()`, which resets the mark/quote bookkeeping (so a later `startMark()` doesn't throw "already marking") without erasing anything from the screen. `discardMark()` is intentionally not part of the public `PrinterService` interface (that lives in the sibling `dynamic-cli-framework-api` repo) - `SpawnInterfaceAdapter` feature-detects it the same way the codebase already feature-detects `SpawnCapable`/`FetchCapable` (`"discardMark" in printerService`), so a `PrinterService` implementation that doesn't have it just skips the reset rather than breaking.

### Fix 2: harden row-count tracking so the clear can never touch earlier output

`DefaultPrinterService` tracks how many terminal rows to erase via a plain counter (`#markedLineCount`) incremented only for writes made between `startMark()`/`endMark()`; scoping the counter correctly is what guarantees `clearMarked()` never reaches back past the start of the marked block into unrelated, earlier CLI output (banner text, "Searching for plugin..." etc.).

That guarantee depends on every write attributable to the marked region actually completing, and being counted, before `endMark()`/`clearMarked()` run. `DefaultSpawnService.spawn()` violated this: the stdout/stderr draining calls were fired without being awaited (`void this.#pipeLines(proc.stdout, ...)`), so `spawn()` could resolve - and `SpawnInterfaceAdapter` proceed to end the mark and compute the row count to erase - before all buffered child-process output had actually been decoded and delivered through `onOutput`. A process's stdout/stderr pipes can still have buffered data even after `proc.exited` resolves, so this is a genuine race, not just a theoretical one.

The fix awaits both piping promises before `spawn()` returns in every return path (normal exit, non-zero exit, and timeout), guaranteeing all `onOutput` calls - and therefore all row-count increments - have landed before the mark region is closed out. This directly addresses the "clearing more than just the quoted block" symptom: with the counter always fully and exactly reflecting the marked writes, `clearUpLines()` can only ever erase rows that belong to the quoted/marked block itself.

## Test plan

- [x] `bun test` - 772 tests pass, including new coverage:
  - `SpawnInterfaceAdapter`: success clears the marked block; failure leaves it in place and calls `discardMark()` instead of `clearMarked()`
  - `DefaultPrinterService`: `discardMark()` resets state without writing anything, leaves preceding non-marked output untouched, and throws if called without a preceding `startMark()`
  - `DefaultSpawnService`: spawning a command that emits 200 lines right before exiting delivers every line via `onOutput` before `spawn()` resolves (regression test for the piping race)
- [x] `npx oxlint index.ts src/ tests/`
- [x] `npx oxfmt --check index.ts src/ tests/`
- [x] `npx tsc -p tsconfig.json --noEmit`

Refs #150

<!-- flowscripter-agent:v1 -->