### PR TITLE
feat: support version specifiers in plugin add command

### DIFF
--- a/src/service/plugin/command/PluginAddSubCommand.ts
+++ b/src/service/plugin/command/PluginAddSubCommand.ts
@@ -8,6 +8,7 @@ import { PLUGIN_SERVICE_ID } from "@flowscripter/dynamic-cli-framework-api";
 import type { PluginService } from "@flowscripter/dynamic-cli-framework-api";
 import type { VersionedPluginDescriptor } from "@flowscripter/dynamic-plugin-framework";
 import { getPluginId } from "./getPluginId.ts";
+import { parsePluginSpecifier } from "./parsePluginSpecifier.ts";
 
 export class PluginAddSubCommand implements SubCommand {
   readonly name = "add";
@@ -17,7 +18,7 @@ export class PluginAddSubCommand implements SubCommand {
   readonly positionals = [
     {
       name: "pluginId",
-      description: "Plugin ID to install (e.g. @scope/name)",
+      description: "Plugin ID to install (e.g. @scope/name or @scope/name:version)",
       type: ValueTypeName.STRING,
     },
   ];
@@ -26,7 +27,7 @@ export class PluginAddSubCommand implements SubCommand {
     const printerService = context.getServiceById(PRINTER_SERVICE_ID) as PrinterService;
     const pluginService = context.getServiceById(PLUGIN_SERVICE_ID) as PluginService;
 
-    const pluginId = argumentValues["pluginId"] as string;
+    const { pluginId, version } = parsePluginSpecifier(argumentValues["pluginId"] as string);
     await printerService.info(`Searching for plugin: ${pluginId}\n`, Icon.INFORMATION);
 
     let descriptor: VersionedPluginDescriptor | undefined;
@@ -35,6 +36,12 @@ export class PluginAddSubCommand implements SubCommand {
         descriptor = d;
         break;
       }
+    }
+
+    if (descriptor && version) {
+      // search only ever returns the latest version - substitute the explicitly requested
+      // version so install() is asked for the correct one.
+      descriptor = { ...descriptor, version };
     }
 
     if (!descriptor) {
@@ -52,7 +59,7 @@ export class PluginAddSubCommand implements SubCommand {
         pluginId,
         scope,
         name,
-        version: "latest",
+        version: version ?? "latest",
         extensionPoints: [],
       };
     }

--- a/src/service/plugin/command/parsePluginSpecifier.ts
+++ b/src/service/plugin/command/parsePluginSpecifier.ts
@@ -1,0 +1,22 @@
+/**
+ * Splits a plugin specifier into a bare plugin ID and an optional version.
+ *
+ * The specifier is split on the *last* `:` character, if present. Scoped npm package names
+ * (e.g. `@scope/name`) never legitimately contain a literal `:`, so this split cannot collide
+ * with the scope/slash structure of the plugin ID itself.
+ *
+ * Everything after the last `:` is always treated as the requested version, including
+ * non-semver tags such as `latest` or `next` - no validation is performed on the tail.
+ *
+ * @param specifier raw plugin specifier, e.g. `@scope/name`, `@scope/name:3.0.0` or `name:latest`.
+ */
+export function parsePluginSpecifier(specifier: string): { pluginId: string; version?: string } {
+  const index = specifier.lastIndexOf(":");
+  if (index === -1) {
+    return { pluginId: specifier };
+  }
+  return {
+    pluginId: specifier.slice(0, index),
+    version: specifier.slice(index + 1),
+  };
+}

--- a/tests/service/plugin/command/PluginAddSubCommand.test.ts
+++ b/tests/service/plugin/command/PluginAddSubCommand.test.ts
@@ -1,4 +1,4 @@
-import { describe, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import type {
   SearchQuery,
   VersionedPluginDescriptor,
@@ -65,5 +65,85 @@ describe("PluginAddSubCommand", () => {
       dummyStderr.getString(),
       "ℹ Searching for plugin: @scope/plugin\nℹ Installing @scope/plugin...\n",
     );
+  });
+
+  test("strips the version from the specifier before searching, and passes it to install", async () => {
+    const { context, dummyStderr } = buildContext();
+
+    const searchQueries: Readonly<SearchQuery>[] = [];
+    let installedDescriptor: VersionedPluginDescriptor | undefined;
+    const fakePluginService: PluginService = {
+      search: async function* (query: Readonly<SearchQuery>) {
+        searchQueries.push(query);
+        yield descriptor;
+      },
+      install: async (d: Readonly<VersionedPluginDescriptor>) => {
+        installedDescriptor = d as VersionedPluginDescriptor;
+      },
+      uninstall: async () => {},
+      listInstalled: async function* () {},
+      checkForUpdates: async function* () {},
+    };
+    context.addServiceInstance(PLUGIN_SERVICE_ID, fakePluginService);
+
+    const command = new PluginAddSubCommand();
+    await command.execute(context, { pluginId: `${descriptor.pluginId}:3.0.0` });
+
+    expect(searchQueries).toEqual([{ text: descriptor.pluginId }]);
+    expect(installedDescriptor?.version).toEqual("3.0.0");
+    expectStringEquals(
+      dummyStderr.getString(),
+      "ℹ Searching for plugin: @scope/plugin\nℹ Installing @scope/plugin...\n",
+    );
+  });
+
+  test("passes a non-semver version tag (e.g. latest) through to install unchanged", async () => {
+    const { context } = buildContext();
+
+    let installedDescriptor: VersionedPluginDescriptor | undefined;
+    const fakePluginService: PluginService = {
+      search: async function* (_query: Readonly<SearchQuery>) {
+        yield descriptor;
+      },
+      install: async (d: Readonly<VersionedPluginDescriptor>) => {
+        installedDescriptor = d as VersionedPluginDescriptor;
+      },
+      uninstall: async () => {},
+      listInstalled: async function* () {},
+      checkForUpdates: async function* () {},
+    };
+    context.addServiceInstance(PLUGIN_SERVICE_ID, fakePluginService);
+
+    const command = new PluginAddSubCommand();
+    await command.execute(context, { pluginId: `${descriptor.pluginId}:latest` });
+
+    expect(installedDescriptor?.version).toEqual("latest");
+  });
+
+  test("falls back to direct install with parsed version when search finds no match", async () => {
+    const { context } = buildContext();
+
+    const searchQueries: Readonly<SearchQuery>[] = [];
+    let installedDescriptor: VersionedPluginDescriptor | undefined;
+    const fakePluginService: PluginService = {
+      search: async function* (query: Readonly<SearchQuery>) {
+        searchQueries.push(query);
+        yield* [];
+      },
+      install: async (d: Readonly<VersionedPluginDescriptor>) => {
+        installedDescriptor = d as VersionedPluginDescriptor;
+      },
+      uninstall: async () => {},
+      listInstalled: async function* () {},
+      checkForUpdates: async function* () {},
+    };
+    context.addServiceInstance(PLUGIN_SERVICE_ID, fakePluginService);
+
+    const command = new PluginAddSubCommand();
+    await command.execute(context, { pluginId: "@other/plugin:2.5.0" });
+
+    expect(searchQueries).toEqual([{ text: "@other/plugin" }]);
+    expect(installedDescriptor?.pluginId).toEqual("@other/plugin");
+    expect(installedDescriptor?.version).toEqual("2.5.0");
   });
 });

--- a/tests/service/plugin/command/parsePluginSpecifier.test.ts
+++ b/tests/service/plugin/command/parsePluginSpecifier.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { parsePluginSpecifier } from "../../../../src/service/plugin/command/parsePluginSpecifier.ts";
+
+describe("parsePluginSpecifier", () => {
+  test("returns pluginId with no version when no colon is present", () => {
+    expect(parsePluginSpecifier("@scope/plugin")).toEqual({ pluginId: "@scope/plugin" });
+  });
+
+  test("returns pluginId with no version for an unscoped name", () => {
+    expect(parsePluginSpecifier("plugin")).toEqual({ pluginId: "plugin" });
+  });
+
+  test("splits a scoped plugin specifier on the last colon", () => {
+    expect(parsePluginSpecifier("@scope/plugin:3.0.0")).toEqual({
+      pluginId: "@scope/plugin",
+      version: "3.0.0",
+    });
+  });
+
+  test("splits an unscoped plugin specifier on the last colon", () => {
+    expect(parsePluginSpecifier("plugin:3.0.0")).toEqual({
+      pluginId: "plugin",
+      version: "3.0.0",
+    });
+  });
+
+  test("treats a non-semver tail as the version, e.g. 'latest'", () => {
+    expect(parsePluginSpecifier("@scope/plugin:latest")).toEqual({
+      pluginId: "@scope/plugin",
+      version: "latest",
+    });
+  });
+
+  test("treats a non-semver tail as the version, e.g. 'next'", () => {
+    expect(parsePluginSpecifier("@scope/plugin:next")).toEqual({
+      pluginId: "@scope/plugin",
+      version: "next",
+    });
+  });
+
+  test("splits on the last colon only, not the first", () => {
+    expect(parsePluginSpecifier("@scope/plugin:1.0.0:extra")).toEqual({
+      pluginId: "@scope/plugin:1.0.0",
+      version: "extra",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds `parsePluginSpecifier()` (`src/service/plugin/command/parsePluginSpecifier.ts`) which splits a raw plugin specifier on the **last** `:` into `{ pluginId, version? }`. Scoped npm package names (`@scope/name`) never contain a literal `:`, so this split is safe regardless of scope. The tail after the last `:` is always treated as the requested version - including non-semver tags like `latest`/`next` - with no validation before splitting.

`PluginAddSubCommand.execute()` now:
- parses the `pluginId` positional up front
- searches using the **bare** `pluginId` only (a version was never useful in the search text - search only ever returns latest anyway)
- if search finds a match and a version was requested, overrides the found descriptor's `version` with the requested one (since search results only reflect latest)
- if search finds no match, the existing direct-install fallback now uses `version ?? "latest"` instead of always hardcoding `"latest"`

Example: `plugin:add @flowscripter/example-cli-plugin:3.0.0` now searches for `@flowscripter/example-cli-plugin` and installs version `3.0.0`.

## Dependency on flowscripter/dynamic-plugin-framework#104

This PR only fixes the parsing/threading at the command layer. The actual install call (`NpmPluginManager.installOne()` in `dynamic-plugin-framework`) previously ignored `descriptor.version` entirely and always installed latest - that's fixed separately in flowscripter/dynamic-plugin-framework#104.

`dynamic-cli-framework` depends on a **published, pinned** version of `@flowscripter/dynamic-plugin-framework` (not a workspace link), so **this PR's version-specifier support will not actually install the requested version end-to-end until flowscripter/dynamic-plugin-framework#104 is merged, released, and this repo's dependency is bumped to that release.** Until then, `plugin:add @scope/name:3.0.0` will correctly parse and search for `@scope/name`, but will still install latest.

Refs #147

## Test plan

- [x] `bun test` - all 776 tests pass, including new coverage: specifier parsing edge cases (no version, `latest`/`next` tags, scoped names, multiple colons), search called with bare name only, version threaded into both the search-match and fallback-install descriptors
- [x] `npx oxlint index.ts src/ tests/` - clean
- [x] `npx oxfmt --check index.ts src/ tests/` - clean
- [x] `npx tsc --noEmit` - clean

<!-- flowscripter-agent:v1 -->