### PR TITLE
chore: bump dynamic-plugin-framework to 2.1.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@flowscripter/dynamic-cli-framework",
       "dependencies": {
         "@flowscripter/dynamic-cli-framework-api": "^2.0.0",
-        "@flowscripter/dynamic-plugin-framework": "2.0.3",
+        "@flowscripter/dynamic-plugin-framework": "2.1.1",
         "emphasize": "^7.0.0",
         "fastest-levenshtein": "^1.0.16",
         "figlet": "^1.11.0",
@@ -31,7 +31,7 @@
   "packages": {
     "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@2.0.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-jeSfXanm+RED9zKSxStOJYmDRi3t7bAaDNSQxI+KhraUMb0iTt+TiWPmDZyBN/Bc76hDX9W/lqN7041OALl2pA=="],
 
-    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@2.0.3", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-qyQn+4v/T0ugsdYRFPsvIU7z2nvY2D0ZVPJ9ZdW0KJCFImY1VB/2fYtCBVTjHK339QXcYM+jBHv5Pvuf0emgEw=="],
+    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@2.1.1", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-0fHxgPAsb1xrnv3J8YdNtK0eOhTuKzM6J/fU4IYJEj5y8qlj7v1SZIO3+jvN3y8aEgYRxd6B2GAfXKk9WGR2Pg=="],
 
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.57.0", "", { "os": "android", "cpu": "arm" }, "sha512-qVBsEO+KugOsCmUHcO8iqNnqc65p7PCKpCs8M66mPZ+Ri+CWbcpoQOEJBg2OTu03+0qu++NK1jj6IzvQVs0Sig=="],
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@flowscripter/dynamic-cli-framework-api": "^2.0.0",
-    "@flowscripter/dynamic-plugin-framework": "2.0.3",
+    "@flowscripter/dynamic-plugin-framework": "2.1.1",
     "emphasize": "^7.0.0",
     "fastest-levenshtein": "^1.0.16",
     "figlet": "^1.11.0",


### PR DESCRIPTION
## Summary
- Bumps \`@flowscripter/dynamic-plugin-framework\` to \`2.1.1\`, which fixes the pre-existing, Windows-only \`plugin:add\` hang. The install command's stdout/stderr are now piped and forwarded manually instead of inherited - a leaked OS handle several hops down the bun/cmd/node process chain can no longer keep a caller's read of our output open past our own exit. See flowscripter/dynamic-plugin-framework#105.

## Test plan
- [x] \`bun test\` — 776 pass, 0 fail
- [x] \`tsc -p tsconfig.build.json --noEmit\` — clean
- [x] \`oxlint .\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvxRNHoMxUCQwEcuvr8h7G