### PR TITLE
fix: dim quoted spawned output no longer neutralized by truecolor

### DIFF
--- a/src/service/printer/terminal/Quote.ts
+++ b/src/service/printer/terminal/Quote.ts
@@ -1,3 +1,4 @@
+import { stripSgr } from "../../../terminal/Ansi.ts";
 import type Styler from "../../../terminal/Styler.ts";
 
 interface Level {
@@ -60,7 +61,9 @@ export default class Quote {
     }
     const endsWithNewline = message.endsWith("\n");
     const raw = endsWithNewline ? message.slice(0, -1) : message;
-    const lines = raw.split("\n").map((line) => this.#prefixLine() + this.#styler.dimText(line));
+    const lines = raw
+      .split("\n")
+      .map((line) => this.#prefixLine() + this.#styler.dimText(stripSgr(line)));
     return lines.join("\n") + (endsWithNewline ? "\n" : "");
   }
 }

--- a/src/terminal/Ansi.ts
+++ b/src/terminal/Ansi.ts
@@ -27,3 +27,11 @@ export function backgroundColorStart(r: number, g: number, b: number): string {
 export function hyperlinkStart(url: string): string {
   return `${OSC}8${SEP}${SEP}${url}${BEL}`;
 }
+
+/**
+ * Strips CSI ("\x1b[...m") SGR escape sequences - e.g. foreground/background color, italic, dim -
+ * from text. Does not touch OSC hyperlink sequences ("\x1b]8;;...").
+ */
+export function stripSgr(text: string): string {
+  return text.replace(/\x1b\[[0-9;]*m/g, ""); // oxlint-disable-line no-control-regex
+}

--- a/tests/service/printer/DefaultPrinterService.test.ts
+++ b/tests/service/printer/DefaultPrinterService.test.ts
@@ -575,6 +575,12 @@ describe("DefaultPrinterService tests", () => {
     expect(output).toContain("\x1b[22m");
     // the quoting mark itself is emitted before the dim start code, i.e. not dimmed
     expect(output.indexOf("┐")).toBeLessThan(output.indexOf("\x1b[2m"));
+    // info() applies an explicit truecolor foreground to the message content before it reaches
+    // the quote - that color must be stripped from the dimmed segment (the quote mark itself is
+    // still colored, which is fine) so it doesn't sit alongside - and visually neutralize, in
+    // most terminal emulators - the dim/faint SGR attribute
+    const dimmedSegment = output.slice(output.indexOf("\x1b[2m"), output.indexOf("\x1b[22m"));
+    expect(dimmedSegment).not.toContain("\x1b[38;2;");
   });
 
   test("nested startQuote/endQuote prefixes lines with branch column on stderr", async () => {


### PR DESCRIPTION
## Summary

PR #152 added `dim()` styling to `Quote.prefixLines()` so quoted spawned-process
output would appear de-emphasized. The dim SGR (2/22 - faint/normal-intensity)
codes were correctly emitted, but they wrapped line content that had *already*
been given an explicit 24-bit truecolor foreground by `PrinterService.info()`
(via `primary()`). Most terminal emulators implement "faint" by blending the
terminal's indexed/default foreground color - when an explicit RGB color is
already set on the same run of text, SGR 2 becomes a visual no-op. This
matches the report on both macOS and Linux: the dim codes were present in the
byte stream, but nothing looked dimmed on screen.

## Fix

`Quote.prefixLines()` now strips any pre-existing SGR color/attribute codes
from the line content before applying `dimText()`, so dim is only ever
combined with the terminal's default foreground - which reliably renders
faint. Added `stripSgr()` to `src/terminal/Ansi.ts` (CSI-only, does not touch
OSC hyperlink sequences) and use it in `Quote.ts`. Strengthened the existing
"dims quoted content but not the quoting marks" test to assert the dimmed
segment contains no leftover truecolor codes.

## Test plan

- [x] `bun test` - 786 pass, 0 fail
- [x] `bunx oxlint index.ts src/ tests/` - clean
- [x] `bunx oxfmt --check` - clean
- [x] `bunx tsc -p tsconfig.build.json` - clean
- [x] `bunx typedoc index.ts` - 0 errors

Refs #148

<!-- flowscripter-agent:v1 -->