### PR TITLE
fix: include resolved version in plugin add log messages

### DIFF
--- a/src/service/plugin/command/PluginAddSubCommand.ts
+++ b/src/service/plugin/command/PluginAddSubCommand.ts
@@ -28,7 +28,8 @@ export class PluginAddSubCommand implements SubCommand {
     const pluginService = context.getServiceById(PLUGIN_SERVICE_ID) as PluginService;
 
     const { pluginId, version } = parsePluginSpecifier(argumentValues["pluginId"] as string);
-    await printerService.info(`Searching for plugin: ${pluginId}\n`, Icon.INFORMATION);
+    const searchLabel = version ? `${pluginId}:${version}` : pluginId;
+    await printerService.info(`Searching for plugin: ${searchLabel}\n`, Icon.INFORMATION);
 
     let descriptor: VersionedPluginDescriptor | undefined;
     for await (const d of pluginService.search({ text: pluginId })) {
@@ -49,7 +50,7 @@ export class PluginAddSubCommand implements SubCommand {
       // This handles cases where the package exists on the registry but is not
       // returned by search (e.g. recently published or low search ranking).
       await printerService.info(
-        `Plugin not found via search, attempting direct install of ${pluginId}...\n`,
+        `Plugin not found via search, attempting direct install of ${searchLabel}...\n`,
         Icon.INFORMATION,
       );
       const parts = pluginId.startsWith("@") ? pluginId.slice(1).split("/") : [undefined, pluginId];
@@ -64,7 +65,11 @@ export class PluginAddSubCommand implements SubCommand {
       };
     }
 
-    await printerService.info(`Installing ${descriptor.pluginId}...\n`, Icon.INFORMATION);
+    const installLabel =
+      descriptor.version && descriptor.version !== "latest"
+        ? `${descriptor.pluginId}@${descriptor.version}`
+        : descriptor.pluginId;
+    await printerService.info(`Installing ${installLabel}...\n`, Icon.INFORMATION);
     await pluginService.install(descriptor);
     await printerService.print(`Plugin ${descriptor.pluginId} installed.\n`, Icon.SUCCESS);
   }

--- a/tests/service/plugin/command/PluginAddSubCommand.test.ts
+++ b/tests/service/plugin/command/PluginAddSubCommand.test.ts
@@ -63,7 +63,7 @@ describe("PluginAddSubCommand", () => {
 
     expectStringEquals(
       dummyStderr.getString(),
-      "ℹ Searching for plugin: @scope/plugin\nℹ Installing @scope/plugin...\n",
+      "ℹ Searching for plugin: @scope/plugin\nℹ Installing @scope/plugin@1.0.0...\n",
     );
   });
 
@@ -93,7 +93,7 @@ describe("PluginAddSubCommand", () => {
     expect(installedDescriptor?.version).toEqual("3.0.0");
     expectStringEquals(
       dummyStderr.getString(),
-      "ℹ Searching for plugin: @scope/plugin\nℹ Installing @scope/plugin...\n",
+      "ℹ Searching for plugin: @scope/plugin:3.0.0\nℹ Installing @scope/plugin@3.0.0...\n",
     );
   });
 
@@ -121,7 +121,7 @@ describe("PluginAddSubCommand", () => {
   });
 
   test("falls back to direct install with parsed version when search finds no match", async () => {
-    const { context } = buildContext();
+    const { context, dummyStderr } = buildContext();
 
     const searchQueries: Readonly<SearchQuery>[] = [];
     let installedDescriptor: VersionedPluginDescriptor | undefined;
@@ -145,5 +145,11 @@ describe("PluginAddSubCommand", () => {
     expect(searchQueries).toEqual([{ text: "@other/plugin" }]);
     expect(installedDescriptor?.pluginId).toEqual("@other/plugin");
     expect(installedDescriptor?.version).toEqual("2.5.0");
+    expectStringEquals(
+      dummyStderr.getString(),
+      "ℹ Searching for plugin: @other/plugin:2.5.0\n" +
+        "ℹ Plugin not found via search, attempting direct install of @other/plugin:2.5.0...\n" +
+        "ℹ Installing @other/plugin@2.5.0...\n",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Follow-up to the version-specifier support merged in #154 (and the dependency bump in #155): `plugin:add` parsed the version correctly but the "Searching for plugin" and "Installing" log lines never showed it, so there was no visible confirmation the version was picked up.
- `PluginAddSubCommand` now prints `pluginId:version` while searching and `pluginId@version` while installing (matching the argument format actually passed to the underlying package manager), whenever a version is present on the resolved descriptor - whether explicitly requested or the one returned by search.
- Updated/added tests in `tests/service/plugin/command/PluginAddSubCommand.test.ts` covering the new log format for the explicit-version, no-version, and fallback-to-direct-install paths.

## Investigation notes (other issues reported in #147, not fixed here)
- **Non-existent version not erroring**: could not reproduce. Tested directly (`bun add pkg@bad-version`), via `bun run index.ts` in example-cli, and via the actual `bun build --compile` binary matching the distributed artifact - all three correctly fail with a non-zero exit and a clear error message propagated through `NpmPluginManager.runCommand`.
- **Hang after "Resolving dependencies"**: could not reproduce despite repeated attempts (cold/warm bun cache, dev mode, and compiled binary) - all completed in well under 2s. Read `DefaultSpawnService.ts` and `SpawnInterfaceAdapter.ts`; the stream-piping fix from #150 (awaiting `pipeStdout`/`pipeStderr` before returning, non-blocking `onOutput` queue) is intact and correct. No postinstall/preinstall scripts exist anywhere in the installed dependency tree that could explain an orphaned-process pipe leak. Root cause remains unconfirmed - flagging rather than guessing at a fix.
- **Fallback-to-direct-install when search misses**: read `PluginAddSubCommand.ts` and `NpmPluginManager.install()`. Left the behavior unchanged - this is a design question for the maintainer, not something to silently change (see issue comment).

## Test plan
- [x] `bun test` (786 pass)
- [x] `bunx oxlint index.ts src/ tests/`
- [x] `bunx oxfmt --check`
- [x] `bunx tsc -p tsconfig.build.json`
- [x] `bunx typedoc index.ts` (0 errors)

Refs #147

<!-- flowscripter-agent:v1 -->