### PR TITLE
refactor: use published checkAvailable interface instead of duck-typed workaround

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "@flowscripter/dynamic-cli-framework",
       "dependencies": {
-        "@flowscripter/dynamic-cli-framework-api": "^2.2.1",
-        "@flowscripter/dynamic-plugin-framework": "2.1.1",
+        "@flowscripter/dynamic-cli-framework-api": "^2.3.0",
+        "@flowscripter/dynamic-plugin-framework": "^2.2.0",
         "emphasize": "^7.0.0",
         "fastest-levenshtein": "^1.0.16",
         "figlet": "^1.11.0",
@@ -29,9 +29,9 @@
     },
   },
   "packages": {
-    "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@2.2.1", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-mu+Ki0aRnkYBEkLClRnadtilvx3c35SBqdOTAnml3wctQ/WNLB9XgiErj+uOu1cEv63mq6tHxx5eYVTySSCCVg=="],
+    "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@2.3.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-L9seTKhhg08RcxSSCZOtDZKWYpHPyMQ2B3PqViqY9iFWitctsZqHjmFi636CEknM1CsXnzdNgSGsusg+pmDRJQ=="],
 
-    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@2.1.1", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-0fHxgPAsb1xrnv3J8YdNtK0eOhTuKzM6J/fU4IYJEj5y8qlj7v1SZIO3+jvN3y8aEgYRxd6B2GAfXKk9WGR2Pg=="],
+    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@2.2.0", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-olNH+JoIF85c8DUkw8PIUFTOoWzlnHYw+5puE6kbxQ4DPoHM5hSKi/uIYZF43uF+4B+hEsbgKpb2806h4OguFQ=="],
 
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.57.0", "", { "os": "android", "cpu": "arm" }, "sha512-qVBsEO+KugOsCmUHcO8iqNnqc65p7PCKpCs8M66mPZ+Ri+CWbcpoQOEJBg2OTu03+0qu++NK1jj6IzvQVs0Sig=="],
 

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "build": "tsc -p tsconfig.build.json"
   },
   "dependencies": {
-    "@flowscripter/dynamic-cli-framework-api": "^2.2.1",
-    "@flowscripter/dynamic-plugin-framework": "2.1.1",
+    "@flowscripter/dynamic-cli-framework-api": "^2.3.0",
+    "@flowscripter/dynamic-plugin-framework": "^2.2.0",
     "emphasize": "^7.0.0",
     "fastest-levenshtein": "^1.0.16",
     "figlet": "^1.11.0",

--- a/src/service/plugin/DefaultPluginService.ts
+++ b/src/service/plugin/DefaultPluginService.ts
@@ -23,13 +23,10 @@ export default class DefaultPluginService implements PluginService {
   readonly #defaultRemoteConfig: NpmjsPluginRepositoryConfig;
   readonly #defaultLocalConfig: NpmPluginRepositoryConfig;
   #pluginManager: MarketplacePluginManager;
-  #remoteConfigs: NpmjsPluginRepositoryConfig[];
-  #fetchFn: FetchInterface["fetch"] = (input, init) => fetch(input, init);
 
   constructor(remoteConfig: NpmjsPluginRepositoryConfig, localConfig: NpmPluginRepositoryConfig) {
     this.#defaultRemoteConfig = remoteConfig;
     this.#defaultLocalConfig = localConfig;
-    this.#remoteConfigs = [remoteConfig];
     this.#pluginManager = new NpmPluginManager(
       [new NpmjsPluginRepository(remoteConfig)],
       new NpmPluginRepository(localConfig),
@@ -53,7 +50,6 @@ export default class DefaultPluginService implements PluginService {
         "local-config",
       )) as unknown as NpmPluginRepositoryConfig;
     }
-    this.#remoteConfigs = remotesConfig;
     this.#pluginManager = new NpmPluginManager(
       remotesConfig.map((config) => new NpmjsPluginRepository(config)),
       new NpmPluginRepository(localConfig),
@@ -61,65 +57,17 @@ export default class DefaultPluginService implements PluginService {
   }
 
   /**
-   * Supply the {@link FetchInterface} to delegate fetch calls to - both for the underlying
-   * `pluginManager` (search/install) and for this service's own direct registry existence
-   * checks (see {@link assertPluginAvailable}), so both respect the host CLI's shutdown
-   * handling and default timeout.
+   * Supply the {@link FetchInterface} for the underlying `pluginManager` to delegate fetch calls
+   * to, so it respects the host CLI's shutdown handling and default timeout.
    */
   setFetch(fetchInterface: FetchInterface): void {
-    this.#fetchFn = fetchInterface.fetch.bind(fetchInterface);
     if (isFetchCapable(this.#pluginManager)) {
       this.#pluginManager.setFetch(fetchInterface);
     }
   }
 
-  #buildHeaders(config: NpmjsPluginRepositoryConfig): Headers {
-    const headers = new Headers();
-    if (config.authToken) {
-      headers.set("Authorization", `Bearer ${config.authToken}`);
-    } else if (config.username !== undefined && config.password !== undefined) {
-      headers.set("Authorization", `Basic ${btoa(`${config.username}:${config.password}`)}`);
-    }
-    return headers;
-  }
-
-  async #existsInAnyRemote(pluginId: string, version?: string): Promise<boolean> {
-    for (const config of this.#remoteConfigs) {
-      const path = version ? `${pluginId}/${version}` : pluginId;
-      const response = await this.#fetchFn(`${config.registryUrl}/${path}`, {
-        headers: this.#buildHeaders(config),
-      });
-      if (response.ok) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Confirm that a plugin package (and, if given, a specific version or dist-tag of it) actually
-   * exists on at least one of the configured remote registries, via a direct lookup against each
-   * registry's package metadata endpoint - not the fuzzy/ranked marketplace `search()`.
-   *
-   * Intended to be called before {@link install}, so a plugin/version that doesn't exist is
-   * reported with a clear error instead of being handed to the underlying package manager
-   * (`bun add`/`npm install`), whose own failure is slower to surface and less direct.
-   *
-   * @param pluginId the package identifier to check (e.g. `@scope/name`).
-   * @param version optional specific version or dist-tag to additionally check for. Skipped when
-   * omitted or `"latest"`, since `"latest"` is always resolvable if the package itself exists.
-   *
-   * @throws if the package (or the specific version/tag) is not found on any configured remote.
-   */
-  async assertPluginAvailable(pluginId: string, version?: string): Promise<void> {
-    if (!(await this.#existsInAnyRemote(pluginId))) {
-      throw new Error(`Plugin ${pluginId} was not found in the configured plugin registry`);
-    }
-    if (version && version !== "latest" && !(await this.#existsInAnyRemote(pluginId, version))) {
-      throw new Error(
-        `Version ${version} of plugin ${pluginId} was not found in the configured plugin registry`,
-      );
-    }
+  async checkAvailable(pluginId: string, version?: string): Promise<boolean> {
+    return this.#pluginManager.checkAvailable(pluginId, version);
   }
 
   search(query: Readonly<SearchQuery>): AsyncIterable<Readonly<VersionedPluginDescriptor>> {

--- a/src/service/plugin/DefaultPluginService.ts
+++ b/src/service/plugin/DefaultPluginService.ts
@@ -6,6 +6,8 @@ import type {
   VersionedPluginDescriptor,
   NpmjsPluginRepositoryConfig,
   NpmPluginRepositoryConfig,
+  FetchCapable,
+  FetchInterface,
 } from "@flowscripter/dynamic-plugin-framework";
 import {
   NpmPluginManager,
@@ -13,14 +15,21 @@ import {
   NpmPluginRepository,
 } from "@flowscripter/dynamic-plugin-framework";
 
+function isFetchCapable(value: unknown): value is FetchCapable {
+  return typeof value === "object" && value !== null && "setFetch" in value;
+}
+
 export default class DefaultPluginService implements PluginService {
   readonly #defaultRemoteConfig: NpmjsPluginRepositoryConfig;
   readonly #defaultLocalConfig: NpmPluginRepositoryConfig;
   #pluginManager: MarketplacePluginManager;
+  #remoteConfigs: NpmjsPluginRepositoryConfig[];
+  #fetchFn: FetchInterface["fetch"] = (input, init) => fetch(input, init);
 
   constructor(remoteConfig: NpmjsPluginRepositoryConfig, localConfig: NpmPluginRepositoryConfig) {
     this.#defaultRemoteConfig = remoteConfig;
     this.#defaultLocalConfig = localConfig;
+    this.#remoteConfigs = [remoteConfig];
     this.#pluginManager = new NpmPluginManager(
       [new NpmjsPluginRepository(remoteConfig)],
       new NpmPluginRepository(localConfig),
@@ -44,10 +53,73 @@ export default class DefaultPluginService implements PluginService {
         "local-config",
       )) as unknown as NpmPluginRepositoryConfig;
     }
+    this.#remoteConfigs = remotesConfig;
     this.#pluginManager = new NpmPluginManager(
       remotesConfig.map((config) => new NpmjsPluginRepository(config)),
       new NpmPluginRepository(localConfig),
     );
+  }
+
+  /**
+   * Supply the {@link FetchInterface} to delegate fetch calls to - both for the underlying
+   * `pluginManager` (search/install) and for this service's own direct registry existence
+   * checks (see {@link assertPluginAvailable}), so both respect the host CLI's shutdown
+   * handling and default timeout.
+   */
+  setFetch(fetchInterface: FetchInterface): void {
+    this.#fetchFn = fetchInterface.fetch.bind(fetchInterface);
+    if (isFetchCapable(this.#pluginManager)) {
+      this.#pluginManager.setFetch(fetchInterface);
+    }
+  }
+
+  #buildHeaders(config: NpmjsPluginRepositoryConfig): Headers {
+    const headers = new Headers();
+    if (config.authToken) {
+      headers.set("Authorization", `Bearer ${config.authToken}`);
+    } else if (config.username !== undefined && config.password !== undefined) {
+      headers.set("Authorization", `Basic ${btoa(`${config.username}:${config.password}`)}`);
+    }
+    return headers;
+  }
+
+  async #existsInAnyRemote(pluginId: string, version?: string): Promise<boolean> {
+    for (const config of this.#remoteConfigs) {
+      const path = version ? `${pluginId}/${version}` : pluginId;
+      const response = await this.#fetchFn(`${config.registryUrl}/${path}`, {
+        headers: this.#buildHeaders(config),
+      });
+      if (response.ok) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Confirm that a plugin package (and, if given, a specific version or dist-tag of it) actually
+   * exists on at least one of the configured remote registries, via a direct lookup against each
+   * registry's package metadata endpoint - not the fuzzy/ranked marketplace `search()`.
+   *
+   * Intended to be called before {@link install}, so a plugin/version that doesn't exist is
+   * reported with a clear error instead of being handed to the underlying package manager
+   * (`bun add`/`npm install`), whose own failure is slower to surface and less direct.
+   *
+   * @param pluginId the package identifier to check (e.g. `@scope/name`).
+   * @param version optional specific version or dist-tag to additionally check for. Skipped when
+   * omitted or `"latest"`, since `"latest"` is always resolvable if the package itself exists.
+   *
+   * @throws if the package (or the specific version/tag) is not found on any configured remote.
+   */
+  async assertPluginAvailable(pluginId: string, version?: string): Promise<void> {
+    if (!(await this.#existsInAnyRemote(pluginId))) {
+      throw new Error(`Plugin ${pluginId} was not found in the configured plugin registry`);
+    }
+    if (version && version !== "latest" && !(await this.#existsInAnyRemote(pluginId, version))) {
+      throw new Error(
+        `Version ${version} of plugin ${pluginId} was not found in the configured plugin registry`,
+      );
+    }
   }
 
   search(query: Readonly<SearchQuery>): AsyncIterable<Readonly<VersionedPluginDescriptor>> {

--- a/src/service/plugin/PluginServiceProvider.ts
+++ b/src/service/plugin/PluginServiceProvider.ts
@@ -12,7 +12,6 @@ import { DYNAMIC_CLI_FRAMEWORK_SERVICE_PROVIDER_FACTORY_EXTENSION_POINT } from "
 import type { CommandFactory } from "@flowscripter/dynamic-cli-framework-api";
 import type { ServiceProviderFactory } from "@flowscripter/dynamic-cli-framework-api";
 import type {
-  FetchCapable,
   NpmjsPluginRepositoryConfig,
   NpmPluginRepositoryConfig,
   SpawnCapable,
@@ -98,13 +97,11 @@ export default class PluginServiceProvider implements ServiceProvider {
     }
 
     if (!context.doesServiceExist(FETCH_SERVICE_ID)) {
-      logger.debug("FetchService not available, plugin manager will fetch directly");
-    } else if (!("setFetch" in pluginManager)) {
-      logger.debug("Plugin manager does not support FetchCapable, skipping fetch injection");
+      logger.debug("FetchService not available, plugin service will fetch directly");
     } else {
       const fetchService = context.getServiceById(FETCH_SERVICE_ID) as FetchService;
       const adapter = new FetchInterfaceAdapter(fetchService, this.#fetchInterfaceAdapterOptions);
-      (pluginManager as unknown as FetchCapable).setFetch(adapter);
+      pluginService.setFetch(adapter);
     }
 
     await pluginManager.registerExtensions(DYNAMIC_CLI_FRAMEWORK_COMMAND_FACTORY_EXTENSION_POINT);

--- a/src/service/plugin/command/PluginAddSubCommand.ts
+++ b/src/service/plugin/command/PluginAddSubCommand.ts
@@ -10,6 +10,15 @@ import type { VersionedPluginDescriptor } from "@flowscripter/dynamic-plugin-fra
 import { getPluginId } from "./getPluginId.ts";
 import { parsePluginSpecifier } from "./parsePluginSpecifier.ts";
 
+/**
+ * `DefaultPluginService` implements this ahead of it being added to the `PluginService`
+ * interface (see `dynamic-cli-framework-api`) - guarded with a `typeof` check below so this
+ * command still works against any other `PluginService` implementation that doesn't have it.
+ */
+interface PluginServiceWithAvailabilityCheck extends PluginService {
+  assertPluginAvailable?(pluginId: string, version?: string): Promise<void>;
+}
+
 export class PluginAddSubCommand implements SubCommand {
   readonly name = "add";
   readonly description = "Install a remote plugin";
@@ -69,7 +78,27 @@ export class PluginAddSubCommand implements SubCommand {
       descriptor.version && descriptor.version !== "latest"
         ? `${descriptor.pluginId}@${descriptor.version}`
         : descriptor.pluginId;
-    await printerService.info(`Installing ${installLabel}...\n`, Icon.INFORMATION);
+
+    const availabilityCheck = (pluginService as PluginServiceWithAvailabilityCheck)
+      .assertPluginAvailable;
+    if (typeof availabilityCheck === "function") {
+      // Confirm the package (and specific version/tag, if requested) actually exists on the
+      // remote registry via a direct lookup before invoking the package manager - so a
+      // non-existent plugin or version is reported clearly instead of failing later (and less
+      // clearly) inside `bun add`/`npm install`.
+      await availabilityCheck.call(pluginService, descriptor.pluginId, descriptor.version);
+    }
+
+    // A cold package manager cache (first install after a fresh `~/.example-cli`, container,
+    // or CI runner) can take noticeably longer to resolve dependencies than a warm one - long
+    // enough that, without a hint, it can look hung. This is a static, always-shown message
+    // rather than a timer-based "still working..." indicator, since spawn output is streamed
+    // through as it arrives (see SpawnInterfaceAdapter) and there's no reliable signal here for
+    // "this specific run is unusually slow" versus "this is just how long it takes".
+    await printerService.info(
+      `Installing ${installLabel}... (this may take a while on first run)\n`,
+      Icon.INFORMATION,
+    );
     await pluginService.install(descriptor);
     await printerService.print(`Plugin ${descriptor.pluginId} installed.\n`, Icon.SUCCESS);
   }

--- a/src/service/plugin/command/PluginAddSubCommand.ts
+++ b/src/service/plugin/command/PluginAddSubCommand.ts
@@ -10,15 +10,6 @@ import type { VersionedPluginDescriptor } from "@flowscripter/dynamic-plugin-fra
 import { getPluginId } from "./getPluginId.ts";
 import { parsePluginSpecifier } from "./parsePluginSpecifier.ts";
 
-/**
- * `DefaultPluginService` implements this ahead of it being added to the `PluginService`
- * interface (see `dynamic-cli-framework-api`) - guarded with a `typeof` check below so this
- * command still works against any other `PluginService` implementation that doesn't have it.
- */
-interface PluginServiceWithAvailabilityCheck extends PluginService {
-  assertPluginAvailable?(pluginId: string, version?: string): Promise<void>;
-}
-
 export class PluginAddSubCommand implements SubCommand {
   readonly name = "add";
   readonly description = "Install a remote plugin";
@@ -79,26 +70,20 @@ export class PluginAddSubCommand implements SubCommand {
         ? `${descriptor.pluginId}@${descriptor.version}`
         : descriptor.pluginId;
 
-    const availabilityCheck = (pluginService as PluginServiceWithAvailabilityCheck)
-      .assertPluginAvailable;
-    if (typeof availabilityCheck === "function") {
-      // Confirm the package (and specific version/tag, if requested) actually exists on the
-      // remote registry via a direct lookup before invoking the package manager - so a
-      // non-existent plugin or version is reported clearly instead of failing later (and less
-      // clearly) inside `bun add`/`npm install`.
-      await availabilityCheck.call(pluginService, descriptor.pluginId, descriptor.version);
+    // Confirm the package (and specific version/tag, if requested) actually exists on the
+    // remote marketplace before invoking the package manager - so a non-existent plugin or
+    // version is reported clearly instead of failing later (and less clearly) inside
+    // `bun add`/`npm install`.
+    const versionToCheck = descriptor.version === "latest" ? undefined : descriptor.version;
+    if (!(await pluginService.checkAvailable(descriptor.pluginId, versionToCheck))) {
+      throw new Error(
+        versionToCheck
+          ? `Version ${versionToCheck} of plugin ${descriptor.pluginId} was not found in the configured plugin registry`
+          : `Plugin ${descriptor.pluginId} was not found in the configured plugin registry`,
+      );
     }
 
-    // A cold package manager cache (first install after a fresh `~/.example-cli`, container,
-    // or CI runner) can take noticeably longer to resolve dependencies than a warm one - long
-    // enough that, without a hint, it can look hung. This is a static, always-shown message
-    // rather than a timer-based "still working..." indicator, since spawn output is streamed
-    // through as it arrives (see SpawnInterfaceAdapter) and there's no reliable signal here for
-    // "this specific run is unusually slow" versus "this is just how long it takes".
-    await printerService.info(
-      `Installing ${installLabel}... (this may take a while on first run)\n`,
-      Icon.INFORMATION,
-    );
+    await printerService.info(`Installing ${installLabel}...\n`, Icon.INFORMATION);
     await pluginService.install(descriptor);
     await printerService.print(`Plugin ${descriptor.pluginId} installed.\n`, Icon.SUCCESS);
   }

--- a/tests/service/plugin/DefaultPluginService.test.ts
+++ b/tests/service/plugin/DefaultPluginService.test.ts
@@ -167,7 +167,7 @@ describe("DefaultPluginService", () => {
       service.setFetch(
         makeFetch((url) => {
           requestedUrls.push(url);
-          return { ok: url.startsWith("https://second.example.com") };
+          return { ok: url === "https://second.example.com/@scope/plugin" };
         }),
       );
 

--- a/tests/service/plugin/DefaultPluginService.test.ts
+++ b/tests/service/plugin/DefaultPluginService.test.ts
@@ -7,10 +7,21 @@ import type {
 } from "@flowscripter/dynamic-plugin-framework";
 import DefaultPluginService from "../../../src/service/plugin/DefaultPluginService.ts";
 
-function makeFetch(handler: (url: string, init?: RequestInit) => { ok: boolean }): FetchInterface {
+function pluginDoc(version: string): Record<string, unknown> {
+  return { version, keywords: ["ns"], ns: { extensionPoints: ["some-extension-point"] } };
+}
+
+function makeDocFetch(
+  handler: (url: string) => { ok: boolean; doc?: Record<string, unknown> },
+): FetchInterface {
   return {
-    fetch: (input: string, init?: RequestInit) =>
-      Promise.resolve(handler(input, init) as unknown as Response),
+    fetch: (input: string) => {
+      const result = handler(input);
+      return Promise.resolve({
+        ok: result.ok,
+        json: () => Promise.resolve(result.doc ?? {}),
+      } as unknown as Response);
+    },
   };
 }
 
@@ -85,71 +96,33 @@ describe("DefaultPluginService", () => {
     expect(service.pluginManager).toBeDefined();
   });
 
-  describe("assertPluginAvailable", () => {
-    test("resolves when the package exists and no version is requested", async () => {
+  describe("checkAvailable", () => {
+    test("resolves true when the package exists and no version is requested", async () => {
       const service = new DefaultPluginService(getRemoteConfig(), getLocalConfig());
-      const requestedUrls: string[] = [];
-      service.setFetch(
-        makeFetch((url) => {
-          requestedUrls.push(url);
-          return { ok: true };
-        }),
-      );
+      service.setFetch(makeDocFetch(() => ({ ok: true, doc: pluginDoc("1.0.0") })));
 
-      await service.assertPluginAvailable("@scope/plugin");
-
-      expect(requestedUrls).toEqual(["https://registry.npmjs.org/@scope/plugin"]);
+      expect(await service.checkAvailable("@scope/plugin")).toBe(true);
     });
 
-    test("resolves when the package and requested version both exist", async () => {
+    test("resolves true when the package and requested version both exist", async () => {
       const service = new DefaultPluginService(getRemoteConfig(), getLocalConfig());
-      const requestedUrls: string[] = [];
-      service.setFetch(
-        makeFetch((url) => {
-          requestedUrls.push(url);
-          return { ok: true };
-        }),
-      );
+      service.setFetch(makeDocFetch(() => ({ ok: true, doc: pluginDoc("3.0.0") })));
 
-      await service.assertPluginAvailable("@scope/plugin", "3.0.0");
-
-      expect(requestedUrls).toEqual([
-        "https://registry.npmjs.org/@scope/plugin",
-        "https://registry.npmjs.org/@scope/plugin/3.0.0",
-      ]);
+      expect(await service.checkAvailable("@scope/plugin", "3.0.0")).toBe(true);
     });
 
-    test("skips the version check when version is 'latest'", async () => {
+    test("resolves false when the package exists but the requested version does not", async () => {
       const service = new DefaultPluginService(getRemoteConfig(), getLocalConfig());
-      const requestedUrls: string[] = [];
-      service.setFetch(
-        makeFetch((url) => {
-          requestedUrls.push(url);
-          return { ok: true };
-        }),
-      );
+      service.setFetch(makeDocFetch(() => ({ ok: true, doc: pluginDoc("1.0.0") })));
 
-      await service.assertPluginAvailable("@scope/plugin", "latest");
-
-      expect(requestedUrls).toEqual(["https://registry.npmjs.org/@scope/plugin"]);
+      expect(await service.checkAvailable("@scope/plugin", "9.9.9")).toBe(false);
     });
 
-    test("throws a clear error when the package does not exist", async () => {
+    test("resolves false when the package does not exist", async () => {
       const service = new DefaultPluginService(getRemoteConfig(), getLocalConfig());
-      service.setFetch(makeFetch(() => ({ ok: false })));
+      service.setFetch(makeDocFetch(() => ({ ok: false })));
 
-      await expect(service.assertPluginAvailable("@scope/missing")).rejects.toThrow(
-        "Plugin @scope/missing was not found in the configured plugin registry",
-      );
-    });
-
-    test("throws a clear error when the package exists but the requested version does not", async () => {
-      const service = new DefaultPluginService(getRemoteConfig(), getLocalConfig());
-      service.setFetch(makeFetch((url) => ({ ok: !url.endsWith("/9.9.9") })));
-
-      await expect(service.assertPluginAvailable("@scope/plugin", "9.9.9")).rejects.toThrow(
-        "Version 9.9.9 of plugin @scope/plugin was not found in the configured plugin registry",
-      );
+      expect(await service.checkAvailable("@scope/missing")).toBe(false);
     });
 
     test("checks across all configured remotes and succeeds if any one has it", async () => {
@@ -165,37 +138,17 @@ describe("DefaultPluginService", () => {
       } as unknown as KeyValueService);
       const requestedUrls: string[] = [];
       service.setFetch(
-        makeFetch((url) => {
+        makeDocFetch((url) => {
           requestedUrls.push(url);
-          return { ok: url === "https://second.example.com/@scope/plugin" };
+          return { ok: url.startsWith("https://second.example.com"), doc: pluginDoc("1.0.0") };
         }),
       );
 
-      await service.assertPluginAvailable("@scope/plugin");
-
+      expect(await service.checkAvailable("@scope/plugin")).toBe(true);
       expect(requestedUrls).toEqual([
-        "https://first.example.com/@scope/plugin",
-        "https://second.example.com/@scope/plugin",
+        "https://first.example.com/@scope/plugin/latest",
+        "https://second.example.com/@scope/plugin/latest",
       ]);
-    });
-
-    test("sends a Bearer Authorization header when authToken is configured", async () => {
-      const remoteConfig: NpmjsPluginRepositoryConfig = {
-        ...getRemoteConfig(),
-        authToken: "secret-token",
-      };
-      const service = new DefaultPluginService(remoteConfig, getLocalConfig());
-      const sentAuthHeaders: Array<string | null> = [];
-      service.setFetch({
-        fetch: (_input: string, init?: RequestInit) => {
-          sentAuthHeaders.push((init!.headers as Headers).get("Authorization"));
-          return Promise.resolve({ ok: true } as unknown as Response);
-        },
-      });
-
-      await service.assertPluginAvailable("@scope/plugin");
-
-      expect(sentAuthHeaders).toEqual(["Bearer secret-token"]);
     });
   });
 });

--- a/tests/service/plugin/DefaultPluginService.test.ts
+++ b/tests/service/plugin/DefaultPluginService.test.ts
@@ -140,7 +140,10 @@ describe("DefaultPluginService", () => {
       service.setFetch(
         makeDocFetch((url) => {
           requestedUrls.push(url);
-          return { ok: new URL(url).origin === "https://second.example.com", doc: pluginDoc("1.0.0") };
+          return {
+            ok: new URL(url).origin === "https://second.example.com",
+            doc: pluginDoc("1.0.0"),
+          };
         }),
       );
 

--- a/tests/service/plugin/DefaultPluginService.test.ts
+++ b/tests/service/plugin/DefaultPluginService.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, test } from "bun:test";
 import type { KeyValueService } from "@flowscripter/dynamic-cli-framework-api";
 import type {
+  FetchInterface,
   NpmjsPluginRepositoryConfig,
   NpmPluginRepositoryConfig,
 } from "@flowscripter/dynamic-plugin-framework";
 import DefaultPluginService from "../../../src/service/plugin/DefaultPluginService.ts";
+
+function makeFetch(handler: (url: string, init?: RequestInit) => { ok: boolean }): FetchInterface {
+  return {
+    fetch: (input: string, init?: RequestInit) =>
+      Promise.resolve(handler(input, init) as unknown as Response),
+  };
+}
 
 function getRemoteConfig(): NpmjsPluginRepositoryConfig {
   return {
@@ -75,5 +83,119 @@ describe("DefaultPluginService", () => {
       }),
     );
     expect(service.pluginManager).toBeDefined();
+  });
+
+  describe("assertPluginAvailable", () => {
+    test("resolves when the package exists and no version is requested", async () => {
+      const service = new DefaultPluginService(getRemoteConfig(), getLocalConfig());
+      const requestedUrls: string[] = [];
+      service.setFetch(
+        makeFetch((url) => {
+          requestedUrls.push(url);
+          return { ok: true };
+        }),
+      );
+
+      await service.assertPluginAvailable("@scope/plugin");
+
+      expect(requestedUrls).toEqual(["https://registry.npmjs.org/@scope/plugin"]);
+    });
+
+    test("resolves when the package and requested version both exist", async () => {
+      const service = new DefaultPluginService(getRemoteConfig(), getLocalConfig());
+      const requestedUrls: string[] = [];
+      service.setFetch(
+        makeFetch((url) => {
+          requestedUrls.push(url);
+          return { ok: true };
+        }),
+      );
+
+      await service.assertPluginAvailable("@scope/plugin", "3.0.0");
+
+      expect(requestedUrls).toEqual([
+        "https://registry.npmjs.org/@scope/plugin",
+        "https://registry.npmjs.org/@scope/plugin/3.0.0",
+      ]);
+    });
+
+    test("skips the version check when version is 'latest'", async () => {
+      const service = new DefaultPluginService(getRemoteConfig(), getLocalConfig());
+      const requestedUrls: string[] = [];
+      service.setFetch(
+        makeFetch((url) => {
+          requestedUrls.push(url);
+          return { ok: true };
+        }),
+      );
+
+      await service.assertPluginAvailable("@scope/plugin", "latest");
+
+      expect(requestedUrls).toEqual(["https://registry.npmjs.org/@scope/plugin"]);
+    });
+
+    test("throws a clear error when the package does not exist", async () => {
+      const service = new DefaultPluginService(getRemoteConfig(), getLocalConfig());
+      service.setFetch(makeFetch(() => ({ ok: false })));
+
+      await expect(service.assertPluginAvailable("@scope/missing")).rejects.toThrow(
+        "Plugin @scope/missing was not found in the configured plugin registry",
+      );
+    });
+
+    test("throws a clear error when the package exists but the requested version does not", async () => {
+      const service = new DefaultPluginService(getRemoteConfig(), getLocalConfig());
+      service.setFetch(makeFetch((url) => ({ ok: !url.endsWith("/9.9.9") })));
+
+      await expect(service.assertPluginAvailable("@scope/plugin", "9.9.9")).rejects.toThrow(
+        "Version 9.9.9 of plugin @scope/plugin was not found in the configured plugin registry",
+      );
+    });
+
+    test("checks across all configured remotes and succeeds if any one has it", async () => {
+      const service = new DefaultPluginService(getRemoteConfig(), getLocalConfig());
+      const remotesConfig: NpmjsPluginRepositoryConfig[] = [
+        { name: "first", registryUrl: "https://first.example.com", packageJsonNamespace: "ns" },
+        { name: "second", registryUrl: "https://second.example.com", packageJsonNamespace: "ns" },
+      ];
+      await service.applyKeyValueOverrides({
+        has: (key: string) => Promise.resolve(key === "remotes-config"),
+        get: () => Promise.resolve(remotesConfig),
+        set: () => Promise.resolve(),
+      } as unknown as KeyValueService);
+      const requestedUrls: string[] = [];
+      service.setFetch(
+        makeFetch((url) => {
+          requestedUrls.push(url);
+          return { ok: url.startsWith("https://second.example.com") };
+        }),
+      );
+
+      await service.assertPluginAvailable("@scope/plugin");
+
+      expect(requestedUrls).toEqual([
+        "https://first.example.com/@scope/plugin",
+        "https://second.example.com/@scope/plugin",
+      ]);
+    });
+
+    test("sends a Bearer Authorization header when authToken is configured", async () => {
+      const remoteConfig: NpmjsPluginRepositoryConfig = {
+        ...getRemoteConfig(),
+        authToken: "secret-token",
+      };
+      const service = new DefaultPluginService(remoteConfig, getLocalConfig());
+      const sentAuthHeaders: Array<string | null> = [];
+      service.setFetch({
+        fetch: (_input: string, init?: RequestInit) => {
+          sentAuthHeaders.push((init!.headers as Headers).get("Authorization"));
+          return Promise.resolve({ ok: true } as unknown as Response);
+        },
+      });
+
+      await service.assertPluginAvailable("@scope/plugin");
+
+      expect(sentAuthHeaders).toEqual(["Bearer secret-token"]);
+    });
   });
 });

--- a/tests/service/plugin/DefaultPluginService.test.ts
+++ b/tests/service/plugin/DefaultPluginService.test.ts
@@ -140,7 +140,7 @@ describe("DefaultPluginService", () => {
       service.setFetch(
         makeDocFetch((url) => {
           requestedUrls.push(url);
-          return { ok: url.startsWith("https://second.example.com"), doc: pluginDoc("1.0.0") };
+          return { ok: new URL(url).origin === "https://second.example.com", doc: pluginDoc("1.0.0") };
         }),
       );
 

--- a/tests/service/plugin/command/PluginAddSubCommand.test.ts
+++ b/tests/service/plugin/command/PluginAddSubCommand.test.ts
@@ -63,7 +63,7 @@ describe("PluginAddSubCommand", () => {
 
     expectStringEquals(
       dummyStderr.getString(),
-      "ℹ Searching for plugin: @scope/plugin\nℹ Installing @scope/plugin@1.0.0...\n",
+      "ℹ Searching for plugin: @scope/plugin\nℹ Installing @scope/plugin@1.0.0... (this may take a while on first run)\n",
     );
   });
 
@@ -93,7 +93,7 @@ describe("PluginAddSubCommand", () => {
     expect(installedDescriptor?.version).toEqual("3.0.0");
     expectStringEquals(
       dummyStderr.getString(),
-      "ℹ Searching for plugin: @scope/plugin:3.0.0\nℹ Installing @scope/plugin@3.0.0...\n",
+      "ℹ Searching for plugin: @scope/plugin:3.0.0\nℹ Installing @scope/plugin@3.0.0... (this may take a while on first run)\n",
     );
   });
 
@@ -149,7 +149,70 @@ describe("PluginAddSubCommand", () => {
       dummyStderr.getString(),
       "ℹ Searching for plugin: @other/plugin:2.5.0\n" +
         "ℹ Plugin not found via search, attempting direct install of @other/plugin:2.5.0...\n" +
-        "ℹ Installing @other/plugin@2.5.0...\n",
+        "ℹ Installing @other/plugin@2.5.0... (this may take a while on first run)\n",
     );
+  });
+
+  test("checks availability before install and installs when it resolves", async () => {
+    const { context } = buildContext();
+
+    let installCalled = false;
+    let checkedPluginId: string | undefined;
+    let checkedVersion: string | undefined;
+    const fakePluginService = {
+      search: async function* (_query: Readonly<SearchQuery>) {
+        yield descriptor;
+      },
+      install: async () => {
+        installCalled = true;
+      },
+      uninstall: async () => {},
+      listInstalled: async function* () {},
+      checkForUpdates: async function* () {},
+      assertPluginAvailable: async (pluginId: string, version?: string) => {
+        checkedPluginId = pluginId;
+        checkedVersion = version;
+      },
+    };
+    context.addServiceInstance(PLUGIN_SERVICE_ID, fakePluginService);
+
+    const command = new PluginAddSubCommand();
+    await command.execute(context, { pluginId: `${descriptor.pluginId}:3.0.0` });
+
+    expect(checkedPluginId).toEqual(descriptor.pluginId);
+    expect(checkedVersion).toEqual("3.0.0");
+    expect(installCalled).toBeTrue();
+  });
+
+  test("does not install when the availability check rejects", async () => {
+    const { context } = buildContext();
+
+    let installCalled = false;
+    const fakePluginService = {
+      search: async function* (_query: Readonly<SearchQuery>) {
+        yield descriptor;
+      },
+      install: async () => {
+        installCalled = true;
+      },
+      uninstall: async () => {},
+      listInstalled: async function* () {},
+      checkForUpdates: async function* () {},
+      assertPluginAvailable: async () => {
+        throw new Error(
+          "Version 9.9.9 of plugin @scope/plugin was not found in the configured plugin registry",
+        );
+      },
+    };
+    context.addServiceInstance(PLUGIN_SERVICE_ID, fakePluginService);
+
+    const command = new PluginAddSubCommand();
+    await expect(
+      command.execute(context, { pluginId: `${descriptor.pluginId}:9.9.9` }),
+    ).rejects.toThrow(
+      "Version 9.9.9 of plugin @scope/plugin was not found in the configured plugin registry",
+    );
+
+    expect(installCalled).toBeFalse();
   });
 });

--- a/tests/service/plugin/command/PluginAddSubCommand.test.ts
+++ b/tests/service/plugin/command/PluginAddSubCommand.test.ts
@@ -51,6 +51,7 @@ describe("PluginAddSubCommand", () => {
       search: async function* (_query: Readonly<SearchQuery>) {
         yield descriptor;
       },
+      checkAvailable: async () => true,
       install: async () => {},
       uninstall: async () => {},
       listInstalled: async function* () {},
@@ -63,7 +64,7 @@ describe("PluginAddSubCommand", () => {
 
     expectStringEquals(
       dummyStderr.getString(),
-      "ℹ Searching for plugin: @scope/plugin\nℹ Installing @scope/plugin@1.0.0... (this may take a while on first run)\n",
+      "ℹ Searching for plugin: @scope/plugin\nℹ Installing @scope/plugin@1.0.0...\n",
     );
   });
 
@@ -77,6 +78,7 @@ describe("PluginAddSubCommand", () => {
         searchQueries.push(query);
         yield descriptor;
       },
+      checkAvailable: async () => true,
       install: async (d: Readonly<VersionedPluginDescriptor>) => {
         installedDescriptor = d as VersionedPluginDescriptor;
       },
@@ -93,7 +95,7 @@ describe("PluginAddSubCommand", () => {
     expect(installedDescriptor?.version).toEqual("3.0.0");
     expectStringEquals(
       dummyStderr.getString(),
-      "ℹ Searching for plugin: @scope/plugin:3.0.0\nℹ Installing @scope/plugin@3.0.0... (this may take a while on first run)\n",
+      "ℹ Searching for plugin: @scope/plugin:3.0.0\nℹ Installing @scope/plugin@3.0.0...\n",
     );
   });
 
@@ -105,6 +107,7 @@ describe("PluginAddSubCommand", () => {
       search: async function* (_query: Readonly<SearchQuery>) {
         yield descriptor;
       },
+      checkAvailable: async () => true,
       install: async (d: Readonly<VersionedPluginDescriptor>) => {
         installedDescriptor = d as VersionedPluginDescriptor;
       },
@@ -130,6 +133,7 @@ describe("PluginAddSubCommand", () => {
         searchQueries.push(query);
         yield* [];
       },
+      checkAvailable: async () => true,
       install: async (d: Readonly<VersionedPluginDescriptor>) => {
         installedDescriptor = d as VersionedPluginDescriptor;
       },
@@ -149,7 +153,7 @@ describe("PluginAddSubCommand", () => {
       dummyStderr.getString(),
       "ℹ Searching for plugin: @other/plugin:2.5.0\n" +
         "ℹ Plugin not found via search, attempting direct install of @other/plugin:2.5.0...\n" +
-        "ℹ Installing @other/plugin@2.5.0... (this may take a while on first run)\n",
+        "ℹ Installing @other/plugin@2.5.0...\n",
     );
   });
 
@@ -159,9 +163,14 @@ describe("PluginAddSubCommand", () => {
     let installCalled = false;
     let checkedPluginId: string | undefined;
     let checkedVersion: string | undefined;
-    const fakePluginService = {
+    const fakePluginService: PluginService = {
       search: async function* (_query: Readonly<SearchQuery>) {
         yield descriptor;
+      },
+      checkAvailable: async (pluginId: string, version?: string) => {
+        checkedPluginId = pluginId;
+        checkedVersion = version;
+        return true;
       },
       install: async () => {
         installCalled = true;
@@ -169,10 +178,6 @@ describe("PluginAddSubCommand", () => {
       uninstall: async () => {},
       listInstalled: async function* () {},
       checkForUpdates: async function* () {},
-      assertPluginAvailable: async (pluginId: string, version?: string) => {
-        checkedPluginId = pluginId;
-        checkedVersion = version;
-      },
     };
     context.addServiceInstance(PLUGIN_SERVICE_ID, fakePluginService);
 
@@ -184,25 +189,21 @@ describe("PluginAddSubCommand", () => {
     expect(installCalled).toBeTrue();
   });
 
-  test("does not install when the availability check rejects", async () => {
+  test("does not install when the availability check resolves false", async () => {
     const { context } = buildContext();
 
     let installCalled = false;
-    const fakePluginService = {
+    const fakePluginService: PluginService = {
       search: async function* (_query: Readonly<SearchQuery>) {
         yield descriptor;
       },
+      checkAvailable: async () => false,
       install: async () => {
         installCalled = true;
       },
       uninstall: async () => {},
       listInstalled: async function* () {},
       checkForUpdates: async function* () {},
-      assertPluginAvailable: async () => {
-        throw new Error(
-          "Version 9.9.9 of plugin @scope/plugin was not found in the configured plugin registry",
-        );
-      },
     };
     context.addServiceInstance(PLUGIN_SERVICE_ID, fakePluginService);
 
@@ -214,5 +215,30 @@ describe("PluginAddSubCommand", () => {
     );
 
     expect(installCalled).toBeFalse();
+  });
+
+  test("skips the version check when the resolved version is 'latest'", async () => {
+    const { context } = buildContext();
+
+    let checkedVersion: string | undefined;
+    const fakePluginService: PluginService = {
+      search: async function* (_query: Readonly<SearchQuery>) {
+        yield* [];
+      },
+      checkAvailable: async (_pluginId: string, version?: string) => {
+        checkedVersion = version;
+        return true;
+      },
+      install: async () => {},
+      uninstall: async () => {},
+      listInstalled: async function* () {},
+      checkForUpdates: async function* () {},
+    };
+    context.addServiceInstance(PLUGIN_SERVICE_ID, fakePluginService);
+
+    const command = new PluginAddSubCommand();
+    await command.execute(context, { pluginId: "@other/plugin" });
+
+    expect(checkedVersion).toBeUndefined();
   });
 });

--- a/tests/service/plugin/command/PluginRemoveSubCommand.test.ts
+++ b/tests/service/plugin/command/PluginRemoveSubCommand.test.ts
@@ -46,6 +46,7 @@ describe("PluginRemoveSubCommand", () => {
 
     const fakePluginService: PluginService = {
       search: async function* () {},
+      checkAvailable: async () => true,
       install: async () => {},
       uninstall: async () => {},
       listInstalled: async function* () {},

--- a/tests/service/plugin/command/PluginUpgradeSubCommand.test.ts
+++ b/tests/service/plugin/command/PluginUpgradeSubCommand.test.ts
@@ -46,6 +46,7 @@ describe("PluginUpgradeSubCommand", () => {
 
     const fakePluginService: PluginService = {
       search: async function* () {},
+      checkAvailable: async () => true,
       install: async () => {},
       uninstall: async () => {},
       listInstalled: async function* () {},


### PR DESCRIPTION
## Summary
- Replaces `DefaultPluginService`'s duck-typed `assertPluginAvailable()` (a direct npm-registry HTTP lookup that `PluginAddSubCommand` had to detect via a `typeof` check) with the `checkAvailable(pluginId, version?)` method now published on both the `MarketplacePluginManager` interface (`dynamic-plugin-framework@2.2.0`) and the `PluginService` interface (`dynamic-cli-framework-api@2.3.0`).
- `DefaultPluginService.checkAvailable()` delegates straight to the underlying `pluginManager`; `PluginAddSubCommand` calls `pluginService.checkAvailable()` directly and raises its own error from the boolean result - no more `"x" in obj` type-guards, `as unknown as X` casts, or bespoke fetch logic.
- Removes the "(this may take a while on first run)" hint text from the plugin add install log message per explicit user request, restoring the original wording (`Installing ${installLabel}...`).
- Bumps `@flowscripter/dynamic-plugin-framework` to `^2.2.0` and `@flowscripter/dynamic-cli-framework-api` to `^2.3.0`, `bun install` to update the lockfile.
- Updates tests covering the old duck-typed behavior to exercise `checkAvailable` directly, and adds `checkAvailable` to hand-written `PluginService` mocks in `PluginRemoveSubCommand.test.ts` / `PluginUpgradeSubCommand.test.ts` so they still satisfy the (now-stricter) interface.

Refs #147

Supersedes #160, which was closed after the duck-typed workaround it introduced was rejected in favor of pushing `checkAvailable` down into the proper published interfaces.

## Test plan
- [x] `bun test` - 791 pass, 0 fail
- [x] `bunx oxlint index.ts src/ tests/` - clean
- [x] `bunx oxfmt --check` - clean
- [x] `bunx tsc -p tsconfig.build.json` - clean
- [x] `bunx typedoc index.ts` - 0 errors

<!-- flowscripter-agent:v1 -->