### PR TITLE
fix: lock in mark/clear fix for plugin:add with real spawn/printer integration tests

### DIFF
--- a/tests/service/plugin/SpawnInterfaceAdapter.test.ts
+++ b/tests/service/plugin/SpawnInterfaceAdapter.test.ts
@@ -2,9 +2,15 @@ import { describe, expect, test } from "bun:test";
 import SpawnInterfaceAdapter from "../../../src/service/plugin/SpawnInterfaceAdapter.ts";
 import type {
   PrinterService,
+  ShutdownService,
   SpawnOptions,
   SpawnService,
 } from "@flowscripter/dynamic-cli-framework-api";
+import DefaultPrinterService from "../../../src/service/printer/DefaultPrinterService.ts";
+import DefaultSpawnService from "../../../src/service/spawn/DefaultSpawnService.ts";
+import TtyTerminal from "../../../src/terminal/TtyTerminal.ts";
+import TtyStyler from "../../../src/terminal/TtyStyler.ts";
+import StreamString from "../../fixtures/StreamString.ts";
 
 interface FakePrinterServiceState {
   calls: string[];
@@ -153,5 +159,89 @@ describe("SpawnInterfaceAdapter tests", () => {
       "clearMarked(1000)",
     ]);
     expect(state.calls).not.toContain("discardMark");
+  });
+
+  test("integration: clears only the spawned block's rows on success, leaving earlier stderr output (e.g. a banner) untouched", async () => {
+    const dummyStdout = new StreamString();
+    const dummyStderr = new StreamString();
+    const printerService = new DefaultPrinterService(
+      dummyStdout.writableStream,
+      dummyStderr.writableStream,
+      true,
+      true,
+      new TtyTerminal(dummyStdout.writeStream),
+      new TtyTerminal(dummyStderr.writeStream),
+      new TtyStyler(3),
+    );
+    printerService.colorEnabled = false;
+    const shutdownService: ShutdownService = {
+      addShutdownListener: () => {},
+      enterLongRunningMode: () => {},
+      leaveLongRunningMode: () => {},
+      isShutdownRequested: false,
+    };
+    const spawnService = new DefaultSpawnService();
+    spawnService.setDependencies(printerService, shutdownService);
+    const adapter = new SpawnInterfaceAdapter(spawnService, printerService);
+
+    // Simulate a banner printed before the spawn runs - this must survive the clear.
+    await printerService.info("banner line 1\n");
+    await printerService.info("banner line 2\n");
+    const preSpawnOutput = dummyStderr.getString();
+
+    const lineCount = 11;
+    const result = await adapter.spawn(
+      ["sh", "-c", `for i in $(seq 1 ${lineCount}); do echo line$i; done`],
+      { cwd: "/tmp" },
+    );
+
+    expect(result).toEqual({ ok: true, exitCode: 0 });
+
+    const finalOutput = dummyStderr.getString();
+    expect(finalOutput.startsWith(preSpawnOutput)).toBeTrue();
+
+    const postSpawnOutput = finalOutput.slice(preSpawnOutput.length);
+    // Exactly `lineCount` erase operations, matching the number of physical lines actually
+    // written by the spawned command - not double, and not extending into the banner.
+    const clearCount = postSpawnOutput.split("\x1b[1A\x1b[2K").length - 1;
+    expect(clearCount).toEqual(lineCount);
+    expect(preSpawnOutput).toEqual("banner line 1\nbanner line 2\n");
+  });
+
+  test("integration: leaves output on screen (does not clear) on failure, via real spawn/printer services", async () => {
+    const dummyStdout = new StreamString();
+    const dummyStderr = new StreamString();
+    const printerService = new DefaultPrinterService(
+      dummyStdout.writableStream,
+      dummyStderr.writableStream,
+      true,
+      true,
+      new TtyTerminal(dummyStdout.writeStream),
+      new TtyTerminal(dummyStderr.writeStream),
+      new TtyStyler(3),
+    );
+    printerService.colorEnabled = false;
+    const shutdownService: ShutdownService = {
+      addShutdownListener: () => {},
+      enterLongRunningMode: () => {},
+      leaveLongRunningMode: () => {},
+      isShutdownRequested: false,
+    };
+    const spawnService = new DefaultSpawnService();
+    spawnService.setDependencies(printerService, shutdownService);
+    const adapter = new SpawnInterfaceAdapter(spawnService, printerService);
+
+    const result = await adapter.spawn(["sh", "-c", "echo diagnostic output; exit 1"], {
+      cwd: "/tmp",
+    });
+
+    expect(result).toEqual({ ok: false, exitCode: 1 });
+    const output = dummyStderr.getString();
+    expect(output).not.toContain("\x1b[1A\x1b[2K");
+    expect(output).toContain("diagnostic output");
+
+    // A subsequent spawn() must not throw "already marking" - bookkeeping was reset.
+    const secondResult = await adapter.spawn(["echo", "hello"], { cwd: "/tmp" });
+    expect(secondResult.ok).toBeTrue();
   });
 });

--- a/tests/service/plugin/SpawnInterfaceAdapter.test.ts
+++ b/tests/service/plugin/SpawnInterfaceAdapter.test.ts
@@ -10,6 +10,7 @@ import DefaultPrinterService from "../../../src/service/printer/DefaultPrinterSe
 import DefaultSpawnService from "../../../src/service/spawn/DefaultSpawnService.ts";
 import TtyTerminal from "../../../src/terminal/TtyTerminal.ts";
 import TtyStyler from "../../../src/terminal/TtyStyler.ts";
+import { tmpdir } from "node:os";
 import StreamString from "../../fixtures/StreamString.ts";
 
 interface FakePrinterServiceState {
@@ -196,7 +197,7 @@ describe("SpawnInterfaceAdapter tests", () => {
         "-e",
         `for (let i = 1; i <= ${lineCount}; i++) { console.log("line" + i); }`,
       ],
-      { cwd: "/tmp" },
+      { cwd: tmpdir() },
     );
 
     expect(result).toEqual({ ok: true, exitCode: 0 });
@@ -237,7 +238,7 @@ describe("SpawnInterfaceAdapter tests", () => {
 
     const result = await adapter.spawn(
       [process.execPath, "-e", `console.log("diagnostic output"); process.exit(1);`],
-      { cwd: "/tmp" },
+      { cwd: tmpdir() },
     );
 
     expect(result).toEqual({ ok: false, exitCode: 1 });
@@ -247,7 +248,7 @@ describe("SpawnInterfaceAdapter tests", () => {
 
     // A subsequent spawn() must not throw "already marking" - bookkeeping was reset.
     const secondResult = await adapter.spawn([process.execPath, "-e", `console.log("hello");`], {
-      cwd: "/tmp",
+      cwd: tmpdir(),
     });
     expect(secondResult.ok).toBeTrue();
   });

--- a/tests/service/plugin/SpawnInterfaceAdapter.test.ts
+++ b/tests/service/plugin/SpawnInterfaceAdapter.test.ts
@@ -191,7 +191,11 @@ describe("SpawnInterfaceAdapter tests", () => {
 
     const lineCount = 11;
     const result = await adapter.spawn(
-      ["sh", "-c", `for i in $(seq 1 ${lineCount}); do echo line$i; done`],
+      [
+        process.execPath,
+        "-e",
+        `for (let i = 1; i <= ${lineCount}; i++) { console.log("line" + i); }`,
+      ],
       { cwd: "/tmp" },
     );
 
@@ -231,9 +235,10 @@ describe("SpawnInterfaceAdapter tests", () => {
     spawnService.setDependencies(printerService, shutdownService);
     const adapter = new SpawnInterfaceAdapter(spawnService, printerService);
 
-    const result = await adapter.spawn(["sh", "-c", "echo diagnostic output; exit 1"], {
-      cwd: "/tmp",
-    });
+    const result = await adapter.spawn(
+      [process.execPath, "-e", `console.log("diagnostic output"); process.exit(1);`],
+      { cwd: "/tmp" },
+    );
 
     expect(result).toEqual({ ok: false, exitCode: 1 });
     const output = dummyStderr.getString();
@@ -241,7 +246,9 @@ describe("SpawnInterfaceAdapter tests", () => {
     expect(output).toContain("diagnostic output");
 
     // A subsequent spawn() must not throw "already marking" - bookkeeping was reset.
-    const secondResult = await adapter.spawn(["echo", "hello"], { cwd: "/tmp" });
+    const secondResult = await adapter.spawn([process.execPath, "-e", `console.log("hello");`], {
+      cwd: "/tmp",
+    });
     expect(secondResult.ok).toBeTrue();
   });
 });


### PR DESCRIPTION
## Summary

Follow-up investigation on #147 after new raw terminal captures (`script` recordings) from the reporter:

- A successful `plugin:add` where the clear erased **more than the spawned block** - it wiped the banner/earlier output too. Raw byte analysis confirmed the clear count was exactly 2x the actual physical output line count, and the quote-bar rendering showed two active quote levels instead of one from the second spawned line onward.
- A failed `plugin:add` where the diagnostic output was **still cleared**, even though it should stay on screen per #150's original fix.

Both symptoms trace to bugs already fixed on `main` by #153 (`SpawnInterfaceAdapter.discardMark()` on failure instead of `clearMarked()`, and `DefaultSpawnService` awaiting both `pipeStdout`/`pipeStderr` before the caller computes the row count to clear). Re-running the exact real npm package from the report (`@flowscripter/example-cli-plugin`) through the current `SpawnInterfaceAdapter`/`DefaultSpawnService`/`DefaultPrinterService` chain does not reproduce either symptom - single quote level, exact row-count match every time.

Existing `SpawnInterfaceAdapter` tests only exercised hand-written fakes for `PrinterService`/`SpawnService`, which couldn't have caught a genuine row-count miscount. This PR adds two integration-level tests wiring up the *real* `DefaultPrinterService` + `DefaultSpawnService` together:

- Asserts a real multi-line spawn only erases its own rows, leaving banner-like content written beforehand untouched (byte-for-byte).
- Asserts a failing spawn leaves its output on screen and resets mark bookkeeping cleanly for a subsequent `spawn()` call.

Also investigated the reporter's third hang hypothesis (race tied to `~/.example-cli` / `~/.examplecli.json` not existing on first run). `ConfigurationServiceProvider` and `configHelper.ts` use only async `node:fs/promises` calls with no sync fs access or blocking retry loops; TTY detection (`stdin.isTTY && stderr.isTTY`) is identical whether wrapped in `script` or a bare pty. No concrete reproducible root cause found - documented as inconclusive (third round) with what was specifically checked and ruled out.

## Test plan

- [x] `bun test` - 793 pass, 0 fail
- [x] `bunx oxlint index.ts src/ tests/` - clean
- [x] `bunx oxfmt --check index.ts src/ tests/` - clean
- [x] `bunx tsc -p tsconfig.build.json` - clean
- [x] `bunx typedoc index.ts` - 0 errors (pre-existing warnings only, unrelated to this change)

Refs #147

<!-- flowscripter-agent:v1 -->