### PR TITLE
fix: bump dynamic-plugin-framework to 2.2.1 to pick up registry fetch timeout fix

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@flowscripter/dynamic-cli-framework",
       "dependencies": {
         "@flowscripter/dynamic-cli-framework-api": "^2.3.0",
-        "@flowscripter/dynamic-plugin-framework": "^2.2.0",
+        "@flowscripter/dynamic-plugin-framework": "^2.2.1",
         "emphasize": "^7.0.0",
         "fastest-levenshtein": "^1.0.16",
         "figlet": "^1.11.0",
@@ -31,7 +31,7 @@
   "packages": {
     "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@2.3.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-L9seTKhhg08RcxSSCZOtDZKWYpHPyMQ2B3PqViqY9iFWitctsZqHjmFi636CEknM1CsXnzdNgSGsusg+pmDRJQ=="],
 
-    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@2.2.0", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-olNH+JoIF85c8DUkw8PIUFTOoWzlnHYw+5puE6kbxQ4DPoHM5hSKi/uIYZF43uF+4B+hEsbgKpb2806h4OguFQ=="],
+    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@2.2.1", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-/cODz4h3L4gbN8mTkv0GZQe6VHOOpc7y1ozB7tMk/C4PAZhVzSWxAA94H34+VzakUaYzB/z3pTkBzHT4i8sPjg=="],
 
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.57.0", "", { "os": "android", "cpu": "arm" }, "sha512-qVBsEO+KugOsCmUHcO8iqNnqc65p7PCKpCs8M66mPZ+Ri+CWbcpoQOEJBg2OTu03+0qu++NK1jj6IzvQVs0Sig=="],
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@flowscripter/dynamic-cli-framework-api": "^2.3.0",
-    "@flowscripter/dynamic-plugin-framework": "^2.2.0",
+    "@flowscripter/dynamic-plugin-framework": "^2.2.1",
     "emphasize": "^7.0.0",
     "fastest-levenshtein": "^1.0.16",
     "figlet": "^1.11.0",


### PR DESCRIPTION
## Summary

Bumps `@flowscripter/dynamic-plugin-framework` from `^2.2.0` to `^2.2.1` to
consume a real bug fix in the sibling repo: registry fetch calls (used by
`search()`, `install()`, and the pre-install `checkAvailable()` check) had
no working timeout, so a stalled network connection to the plugin registry
could hang `plugin:add` indefinitely. Fixed upstream via a manual
`setTimeout`/`AbortController` timeout mechanism (avoiding a Bun-on-Windows
`AbortSignal.timeout()` bug discovered mid-fix).

No source changes needed in this repo - the bug was entirely internal to
`dynamic-plugin-framework`, not consumed differently by this repo's code.

This PR also carries the branch's existing commits (#161's checkAvailable
rework, #162's regression tests) since the branch was reset onto latest
`main` where those are already merged - this commit is the only new change.

Refs #147

## Test plan

- [x] `bun test` - 793 pass, 0 fail
- [x] `bunx oxlint index.ts src/ tests/` - clean
- [x] `bunx oxfmt --check` - clean
- [x] `bunx tsc -p tsconfig.build.json` - 0 errors
- [x] `bunx typedoc index.ts` - 0 errors (21 pre-existing warnings, unrelated to this change)

<!-- flowscripter-agent:v1 -->