### PR TITLE
fix: bump dynamic-plugin-framework to 2.2.2 and forward timeoutMs through SpawnInterfaceAdapter

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@flowscripter/dynamic-cli-framework",
       "dependencies": {
         "@flowscripter/dynamic-cli-framework-api": "^2.3.0",
-        "@flowscripter/dynamic-plugin-framework": "^2.2.1",
+        "@flowscripter/dynamic-plugin-framework": "^2.2.2",
         "emphasize": "^7.0.0",
         "fastest-levenshtein": "^1.0.16",
         "figlet": "^1.11.0",
@@ -31,7 +31,7 @@
   "packages": {
     "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@2.3.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-L9seTKhhg08RcxSSCZOtDZKWYpHPyMQ2B3PqViqY9iFWitctsZqHjmFi636CEknM1CsXnzdNgSGsusg+pmDRJQ=="],
 
-    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@2.2.1", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-/cODz4h3L4gbN8mTkv0GZQe6VHOOpc7y1ozB7tMk/C4PAZhVzSWxAA94H34+VzakUaYzB/z3pTkBzHT4i8sPjg=="],
+    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@2.2.2", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-S/YbHmfu3anV23jrAm+LefvnjLscyXvIpDwwyPjKJOpk8mcofedVMAYkF6JbZkeYNC7+i0Zvu3Zn/k0Wk5wNjQ=="],
 
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.57.0", "", { "os": "android", "cpu": "arm" }, "sha512-qVBsEO+KugOsCmUHcO8iqNnqc65p7PCKpCs8M66mPZ+Ri+CWbcpoQOEJBg2OTu03+0qu++NK1jj6IzvQVs0Sig=="],
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@flowscripter/dynamic-cli-framework-api": "^2.3.0",
-    "@flowscripter/dynamic-plugin-framework": "^2.2.1",
+    "@flowscripter/dynamic-plugin-framework": "^2.2.2",
     "emphasize": "^7.0.0",
     "fastest-levenshtein": "^1.0.16",
     "figlet": "^1.11.0",

--- a/src/service/plugin/SpawnInterfaceAdapter.ts
+++ b/src/service/plugin/SpawnInterfaceAdapter.ts
@@ -32,7 +32,7 @@ export default class SpawnInterfaceAdapter implements SpawnInterface {
 
   public async spawn(
     command: ReadonlyArray<string>,
-    options: { cwd: string },
+    options: { cwd: string; timeoutMs?: number },
   ): Promise<SpawnResult> {
     this.#printerService.startQuote(this.#quoteColor);
     this.#printerService.startMark();
@@ -49,6 +49,7 @@ export default class SpawnInterfaceAdapter implements SpawnInterface {
       cwd: options.cwd,
       mode: "wrapped",
       onOutput,
+      timeoutMs: options.timeoutMs,
     });
 
     await writeQueue;
@@ -68,7 +69,7 @@ export default class SpawnInterfaceAdapter implements SpawnInterface {
       return { ok: true, exitCode: result.exitCode };
     }
     return "timedOut" in result
-      ? { ok: false, error: new Error("Command timed out") }
+      ? { ok: false, timedOut: true }
       : { ok: false, exitCode: result.exitCode, error: result.error };
   }
 }

--- a/tests/service/plugin/SpawnInterfaceAdapter.test.ts
+++ b/tests/service/plugin/SpawnInterfaceAdapter.test.ts
@@ -54,10 +54,12 @@ function getFakePrinterService(): {
 
 function getFakeSpawnService(
   onOutputLines: Array<{ line: string; stream: "stdout" | "stderr" }>,
-  result: { ok: boolean; exitCode?: number; error?: Error },
-): SpawnService {
-  return {
+  result: { ok: boolean; exitCode?: number; error?: Error; timedOut?: boolean },
+): { spawnService: SpawnService; receivedOptions: Array<SpawnOptions | undefined> } {
+  const receivedOptions: Array<SpawnOptions | undefined> = [];
+  const spawnService = {
     spawn: (_command: ReadonlyArray<string>, options?: SpawnOptions) => {
+      receivedOptions.push(options);
       if (options?.onOutput) {
         for (const { line, stream } of onOutputLines) {
           options.onOutput(line, stream);
@@ -66,12 +68,13 @@ function getFakeSpawnService(
       return Promise.resolve(result);
     },
   } as unknown as SpawnService;
+  return { spawnService, receivedOptions };
 }
 
 describe("SpawnInterfaceAdapter tests", () => {
   test("wraps spawn output in a quoted, marked block written via info()", async () => {
     const { printerService, state } = getFakePrinterService();
-    const spawnService = getFakeSpawnService(
+    const { spawnService } = getFakeSpawnService(
       [
         { line: "line1", stream: "stdout" },
         { line: "line2", stream: "stderr" },
@@ -97,7 +100,7 @@ describe("SpawnInterfaceAdapter tests", () => {
 
   test("passes quoteColor and markMinimumDisplayTimeMs options through", async () => {
     const { printerService, state } = getFakePrinterService();
-    const spawnService = getFakeSpawnService([], { ok: true, exitCode: 0 });
+    const { spawnService } = getFakeSpawnService([], { ok: true, exitCode: 0 });
     const adapter = new SpawnInterfaceAdapter(spawnService, printerService, {
       quoteColor: "#ff0000",
       markMinimumDisplayTimeMs: 2000,
@@ -112,7 +115,7 @@ describe("SpawnInterfaceAdapter tests", () => {
   test("maps a failed SpawnResult through", async () => {
     const { printerService } = getFakePrinterService();
     const error = new Error("ENOENT");
-    const spawnService = getFakeSpawnService([], { ok: false, error });
+    const { spawnService } = getFakeSpawnService([], { ok: false, error });
     const adapter = new SpawnInterfaceAdapter(spawnService, printerService);
 
     const result = await adapter.spawn(["nonexistent"], { cwd: "/tmp" });
@@ -122,7 +125,7 @@ describe("SpawnInterfaceAdapter tests", () => {
 
   test("does not clear the marked/quoted block on failure, but resets mark bookkeeping", async () => {
     const { printerService, state } = getFakePrinterService();
-    const spawnService = getFakeSpawnService(
+    const { spawnService } = getFakeSpawnService(
       [{ line: "some diagnostic output", stream: "stderr" }],
       { ok: false, exitCode: 1, error: undefined },
     );
@@ -143,7 +146,7 @@ describe("SpawnInterfaceAdapter tests", () => {
 
   test("clears the marked/quoted block on success", async () => {
     const { printerService, state } = getFakePrinterService();
-    const spawnService = getFakeSpawnService([{ line: "installed ok", stream: "stdout" }], {
+    const { spawnService } = getFakeSpawnService([{ line: "installed ok", stream: "stdout" }], {
       ok: true,
       exitCode: 0,
     });
@@ -251,5 +254,35 @@ describe("SpawnInterfaceAdapter tests", () => {
       cwd: tmpdir(),
     });
     expect(secondResult.ok).toBeTrue();
+  });
+
+  test("forwards timeoutMs from spawn() options through to the underlying SpawnService", async () => {
+    const { printerService } = getFakePrinterService();
+    const { spawnService, receivedOptions } = getFakeSpawnService([], { ok: true, exitCode: 0 });
+    const adapter = new SpawnInterfaceAdapter(spawnService, printerService);
+
+    await adapter.spawn(["bun", "add", "foo"], { cwd: "/tmp", timeoutMs: 5000 });
+
+    expect(receivedOptions[0]?.timeoutMs).toBe(5000);
+  });
+
+  test("omits timeoutMs when not provided to spawn()", async () => {
+    const { printerService } = getFakePrinterService();
+    const { spawnService, receivedOptions } = getFakeSpawnService([], { ok: true, exitCode: 0 });
+    const adapter = new SpawnInterfaceAdapter(spawnService, printerService);
+
+    await adapter.spawn(["bun", "add", "foo"], { cwd: "/tmp" });
+
+    expect(receivedOptions[0]?.timeoutMs).toBeUndefined();
+  });
+
+  test("maps a timed-out SpawnService result to a timedOut SpawnResult", async () => {
+    const { printerService } = getFakePrinterService();
+    const { spawnService } = getFakeSpawnService([], { ok: false, timedOut: true });
+    const adapter = new SpawnInterfaceAdapter(spawnService, printerService);
+
+    const result = await adapter.spawn(["bun", "add", "foo"], { cwd: "/tmp", timeoutMs: 5000 });
+
+    expect(result).toEqual({ ok: false, timedOut: true });
   });
 });


### PR DESCRIPTION
## Summary
- Bump `@flowscripter/dynamic-plugin-framework` to `2.2.2`, which fixes an install-spawn timeout bug in `NpmPluginManager.runCommand()` (root cause of a hung `plugin:add` in example-cli's release workflow).
- `SpawnInterfaceAdapter.spawn()` now accepts `timeoutMs` in its options and forwards it to the underlying `SpawnService.spawn()` call (cli-framework-api's `SpawnOptions.timeoutMs` already existed; it just wasn't threaded through this adapter).
- A timed-out `SpawnService` result is now mapped to `{ ok: false, timedOut: true }` (using dynamic-plugin-framework 2.2.2's new `SpawnResult.timedOut` flag) instead of a synthesized `Error`.

Refs #147

## Test plan
- [x] `bun test` - 786 pass, 0 fail (includes new/updated `SpawnInterfaceAdapter.test.ts` cases covering `timeoutMs` forwarding and `timedOut` result mapping)
- [x] `bunx oxlint index.ts cli-plugin.ts src/ tests/` - clean
- [x] `bunx oxfmt --check index.ts cli-plugin.ts src/ tests/` - clean
- [x] `bunx tsc --noEmit` - clean
- [x] `bunx typedoc --readme none index.ts` - 0 errors (pre-existing unrelated warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1nPLbiXvGgZoKbkutfQvD