### PR TITLE
feat: show actually-installed version in plugin:add success message

### DIFF
--- a/src/service/plugin/command/PluginAddSubCommand.ts
+++ b/src/service/plugin/command/PluginAddSubCommand.ts
@@ -85,6 +85,21 @@ export class PluginAddSubCommand implements SubCommand {
 
     await printerService.info(`Installing ${installLabel}...\n`, Icon.INFORMATION);
     await pluginService.install(descriptor);
-    await printerService.print(`Plugin ${descriptor.pluginId} installed.\n`, Icon.SUCCESS);
+
+    // Look up the actually-installed version rather than trusting `descriptor.version`: when no
+    // version was requested and the plugin wasn't found via search (direct-install fallback),
+    // `descriptor.version` is still the literal placeholder "latest", not a real version number.
+    let installedVersion = descriptor.version;
+    for await (const installed of pluginService.listInstalled()) {
+      if (installed.pluginId === descriptor.pluginId) {
+        installedVersion = installed.version;
+        break;
+      }
+    }
+
+    await printerService.print(
+      `Plugin ${descriptor.pluginId}@${installedVersion} installed.\n`,
+      Icon.SUCCESS,
+    );
   }
 }

--- a/tests/service/plugin/command/PluginAddSubCommand.test.ts
+++ b/tests/service/plugin/command/PluginAddSubCommand.test.ts
@@ -32,7 +32,7 @@ function buildContext() {
   const context = new DefaultContext(getCLIConfig());
   context.addServiceInstance(PRINTER_SERVICE_ID, printer);
 
-  return { context, dummyStderr };
+  return { context, dummyStdout, dummyStderr };
 }
 
 const descriptor: VersionedPluginDescriptor = {
@@ -240,5 +240,55 @@ describe("PluginAddSubCommand", () => {
     await command.execute(context, { pluginId: "@other/plugin" });
 
     expect(checkedVersion).toBeUndefined();
+  });
+
+  test("confirms the explicitly requested version in the installed message", async () => {
+    const { context, dummyStdout } = buildContext();
+
+    const installedDescriptor: VersionedPluginDescriptor = { ...descriptor, version: "3.0.0" };
+    const fakePluginService: PluginService = {
+      search: async function* (_query: Readonly<SearchQuery>) {
+        yield descriptor;
+      },
+      checkAvailable: async () => true,
+      install: async () => {},
+      uninstall: async () => {},
+      listInstalled: async function* () {
+        yield installedDescriptor;
+      },
+      checkForUpdates: async function* () {},
+    };
+    context.addServiceInstance(PLUGIN_SERVICE_ID, fakePluginService);
+
+    const command = new PluginAddSubCommand();
+    await command.execute(context, { pluginId: `${descriptor.pluginId}:3.0.0` });
+
+    expectStringEquals(dummyStdout.getString(), "✔ Plugin @scope/plugin@3.0.0 installed.\n");
+  });
+
+  test("shows the actually-resolved latest version in the installed message, not the literal 'latest'", async () => {
+    const { context, dummyStdout } = buildContext();
+
+    const resolvedDescriptor: VersionedPluginDescriptor = { ...descriptor, version: "4.2.1" };
+    const fakePluginService: PluginService = {
+      // Not found via search, so PluginAddSubCommand falls back to a direct install with
+      // descriptor.version left as the literal placeholder "latest".
+      search: async function* (_query: Readonly<SearchQuery>) {
+        yield* [];
+      },
+      checkAvailable: async () => true,
+      install: async () => {},
+      uninstall: async () => {},
+      listInstalled: async function* () {
+        yield resolvedDescriptor;
+      },
+      checkForUpdates: async function* () {},
+    };
+    context.addServiceInstance(PLUGIN_SERVICE_ID, fakePluginService);
+
+    const command = new PluginAddSubCommand();
+    await command.execute(context, { pluginId: descriptor.pluginId });
+
+    expectStringEquals(dummyStdout.getString(), "✔ Plugin @scope/plugin@4.2.1 installed.\n");
   });
 });


### PR DESCRIPTION
## Summary
- `plugin:add` now prints the *actually installed* version in its success message (e.g. `Plugin @flowscripter/example-cli-plugin@3.0.0 installed.`) instead of always omitting the version.
- Works for both an explicitly requested version (`plugin:add @scope/name:3.0.0`) and an unspecified version that resolves to the npm `latest` dist-tag - in the latter case the real resolved version number is shown, not the literal string `"latest"`.
- Implementation: after `pluginService.install(descriptor)` completes, looks up the installed plugin's real version via `pluginService.listInstalled()` rather than trusting `descriptor.version` (which is only a real version when found via `search()` or explicitly requested - the direct-install fallback path left it as the literal placeholder `"latest"`). No changes needed to `dynamic-cli-framework-api` or `dynamic-plugin-framework` - the local repository already reflects the real installed version post-install.

## Test plan
- [x] `bun test` - 798 pass, including 2 new cases in `PluginAddSubCommand.test.ts`: explicit version confirmed in the message, and resolved-latest version shown (not the literal `"latest"`)
- [x] `bunx oxlint index.ts cli-plugin.ts src/ tests/`
- [x] `bunx oxfmt --check .`
- [x] `bunx tsc --noEmit`
- [x] `bunx typedoc --readme none index.ts` (0 errors, pre-existing warnings only)

Refs #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1nPLbiXvGgZoKbkutfQvD