### PR TITLE
fix: bump dynamic-plugin-framework to 2.2.3 to pick up plugin install ancestor package.json fix

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@flowscripter/dynamic-cli-framework",
       "dependencies": {
         "@flowscripter/dynamic-cli-framework-api": "^2.3.0",
-        "@flowscripter/dynamic-plugin-framework": "^2.2.2",
+        "@flowscripter/dynamic-plugin-framework": "^2.2.3",
         "emphasize": "^7.0.0",
         "fastest-levenshtein": "^1.0.16",
         "figlet": "^1.11.0",
@@ -31,7 +31,7 @@
   "packages": {
     "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@2.3.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-L9seTKhhg08RcxSSCZOtDZKWYpHPyMQ2B3PqViqY9iFWitctsZqHjmFi636CEknM1CsXnzdNgSGsusg+pmDRJQ=="],
 
-    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@2.2.2", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-S/YbHmfu3anV23jrAm+LefvnjLscyXvIpDwwyPjKJOpk8mcofedVMAYkF6JbZkeYNC7+i0Zvu3Zn/k0Wk5wNjQ=="],
+    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@2.2.3", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-vLoGC2LktUVPWqA66CwSzZtjh09zSR2HTuLa8OMGDumePkgZD0UTE9D2jWsd3bFdqcy14eQf3IYRdDM47+wRKg=="],
 
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.57.0", "", { "os": "android", "cpu": "arm" }, "sha512-qVBsEO+KugOsCmUHcO8iqNnqc65p7PCKpCs8M66mPZ+Ri+CWbcpoQOEJBg2OTu03+0qu++NK1jj6IzvQVs0Sig=="],
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@flowscripter/dynamic-cli-framework-api": "^2.3.0",
-    "@flowscripter/dynamic-plugin-framework": "^2.2.2",
+    "@flowscripter/dynamic-plugin-framework": "^2.2.3",
     "emphasize": "^7.0.0",
     "fastest-levenshtein": "^1.0.16",
     "figlet": "^1.11.0",


### PR DESCRIPTION
## Summary

Bumps `@flowscripter/dynamic-plugin-framework` to `^2.2.3` to consume the fix released in flowscripter/dynamic-plugin-framework#109.

That release makes `NpmPluginManager.installOne()` seed a minimal `package.json` in the target plugins directory before running `bun add`. Previously, without that file, Bun would walk up to an ancestor directory's `package.json` and install the plugin there instead, while still reporting success - a silent install failure.

Refs #166

## Test plan

- [x] `bun install` - lockfile updated
- [x] `bun test` - 798 pass, 0 fail
- [x] `bunx oxlint index.ts cli-plugin.ts src/ tests/` - clean
- [x] `bunx oxfmt --check index.ts cli-plugin.ts src/ tests/` - all files correctly formatted
- [x] `bunx tsc --noEmit` - clean
- [x] `bunx typedoc --readme none index.ts` - 0 errors (pre-existing unrelated warnings only)