### PR TITLE
fix: log upgrade check start/completion for #172

### DIFF
--- a/src/service/upgrade/DefaultUpgradeService.ts
+++ b/src/service/upgrade/DefaultUpgradeService.ts
@@ -18,6 +18,9 @@ import {
 } from "@flowscripter/dynamic-cli-framework-api";
 import semver from "semver";
 import type { UpgradeLocationsConfig } from "./UpgradeLocationsConfig.ts";
+import getLogger from "../../util/logger.ts";
+
+const logger = getLogger("DefaultUpgradeService");
 
 // checkForUpgrade() runs opportunistically on every CLI invocation (via BannerServiceProvider),
 // so that opportunistic call is raced against this timeout so it never stalls CLI startup.
@@ -63,6 +66,7 @@ export default class DefaultUpgradeService implements UpgradeService {
 
   public getUpgradeCheckResult(waitForResult = false): Promise<UpgradeCheckResult> {
     if (!this.#upgradeCheckPromise) {
+      logger.debug(() => "Starting upgrade check");
       // Only cache a non-"failed" result. A "failed" result can come from a transient issue
       // (e.g. a network blip, or the opportunistic startup check racing past
       // VERSION_CHECK_TIMEOUT_MS before checkForUpgrade() itself resolves) - caching that would
@@ -70,6 +74,7 @@ export default class DefaultUpgradeService implements UpgradeService {
       // waiting via waitForResult=true) any chance of a fresh attempt for the rest of this
       // process's lifetime.
       this.#upgradeCheckPromise = this.checkForUpgrade().then((result) => {
+        logger.debug(() => `Upgrade check result: ${JSON.stringify(result)}`);
         if (result.status === "failed") {
           this.#upgradeCheckPromise = undefined;
         }


### PR DESCRIPTION
## Summary
The upgrade check itself already runs as part of every default (non-`upgrade`-command) invocation:
- `BannerServiceProvider` calls `upgradeService.getUpgradeCheckResult()` while rendering the banner (racing a 250ms timeout so it never stalls startup).
- `UpgradeServiceProvider.initService()` also unconditionally fires `void upgradeService.getUpgradeCheckResult();` before any of its early-return branches (declined/disabled auto-upgrade only skips the *prompt-to-enable*/*auto-install* flow, not the check itself).

Neither call site nor `getUpgradeCheckResult()`/`checkForUpgrade()` logged anything, so `DYNAMIC_CLI_FRAMEWORK_DEBUG=1` output gave no evidence the check was actually happening - which is what #172 reported.

Added two debug log lines in `DefaultUpgradeService.getUpgradeCheckResult()`: one when a check starts, one with the result (or failure) when it completes. This is not a functional bug - the check was always running - purely a visibility gap.

Refs #172

## Test plan
- [x] `bun test tests/service/upgrade` (44 pass)
- [x] `bun test` (799 pass, full suite)
- [x] `bunx tsc --noEmit` (clean)
- [x] `bunx oxlint index.ts src/ tests/` (clean)
- [x] `bunx oxfmt --check index.ts src/ tests/` (clean)