### PR TITLE
docs: fix invalid trailing commas in plugin repository config example

### DIFF
--- a/README/plugins.md
+++ b/README/plugins.md
@@ -25,11 +25,11 @@ installing a plugin doesn't also pull in this framework's concrete
 service implementations and their dependencies (`figlet`, `emphasize`,
 `highlight.js`, `prettier`, etc.). Declare it as a `peerDependency`:
 
-```jsonc
+```json
 {
   "peerDependencies": {
-    "@flowscripter/dynamic-cli-framework-api": "*",
-  },
+    "@flowscripter/dynamic-cli-framework-api": "*"
+  }
 }
 ```
 
@@ -160,7 +160,7 @@ An end user of the CLI can override the CLI author's default `pluginServiceRemot
 for the full configuration file format), under the `key-values` property scoped to the
 `PluginServiceProvider`'s service ID (`PLUGIN_SERVICE`):
 
-```jsonc
+```json
 {
   "key-values": {
     "services": {
@@ -169,16 +169,16 @@ for the full configuration file format), under the `key-values` property scoped 
           {
             "name": "npmjs",
             "registryUrl": "https://registry.npmjs.org",
-            "packageJsonNamespace": "mypluginframework",
-          },
+            "packageJsonNamespace": "mypluginframework"
+          }
         ],
         "local-config": {
           "nodeModulesPath": "/home/user/.my-cli/plugins/node_modules",
-          "packageJsonNamespace": "mypluginframework",
-        },
-      },
-    },
-  },
+          "packageJsonNamespace": "mypluginframework"
+        }
+      }
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary
The JSON example in README/plugins.md under "Overriding the default plugin repository configuration" had trailing commas before every closing `}`/`]`, which is invalid in standard JSON.

Also changed the code fence from \`jsonc\` to \`json\`: the global \`oxfmt\` pre-push formatting hook treats \`jsonc\`-fenced blocks in markdown as JS-like and re-adds trailing commas on every format pass - that's exactly the mechanism that introduced this bug in the first place. Tagging the fence \`json\` (accurate, since the example has no comments) makes oxfmt preserve strict-JSON formatting.

Refs #174