### PR TITLE
fix: bump dynamic-cli-framework-api to 2.3.2 for #173

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@flowscripter/dynamic-cli-framework",
       "dependencies": {
-        "@flowscripter/dynamic-cli-framework-api": "^2.3.0",
+        "@flowscripter/dynamic-cli-framework-api": "^2.3.2",
         "@flowscripter/dynamic-plugin-framework": "^2.2.3",
         "emphasize": "^7.0.0",
         "fastest-levenshtein": "^1.0.16",
@@ -29,7 +29,7 @@
     },
   },
   "packages": {
-    "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@2.3.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-L9seTKhhg08RcxSSCZOtDZKWYpHPyMQ2B3PqViqY9iFWitctsZqHjmFi636CEknM1CsXnzdNgSGsusg+pmDRJQ=="],
+    "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@2.3.2", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-N6icoIP5WBRt2EUF+PLWZr5iXAbAxa6QGkfBZNbxjJ5Z13+vUyTaTF6jEKGNv/9ekwTTmo0eBvOCqTNtFBi7zw=="],
 
     "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@2.2.3", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-vLoGC2LktUVPWqA66CwSzZtjh09zSR2HTuLa8OMGDumePkgZD0UTE9D2jWsd3bFdqcy14eQf3IYRdDM47+wRKg=="],
 


### PR DESCRIPTION
## Summary
\`dynamic-cli-framework-api\` \`2.3.2\` (already released, contains the \`PLUGIN_SERVICE_ID\` naming fix from #173) is already within this repo's existing \`^2.3.0\` package.json range, but \`bun.lock\` was still resolving \`2.3.0\` exactly. Refreshed the lockfile so the fix actually takes effect - this repo re-exports the constant via \`PluginServiceProvider.serviceId\`, so a real release is needed for the corrected value to show up.

Refs #173

## Test plan
- [x] \`bun test\` (799 pass)
- [x] \`bunx tsc --noEmit\` (clean)
- [x] \`bunx oxlint index.ts src/ tests/\` (clean)
- [x] \`bunx oxfmt --check index.ts src/ tests/\` (clean)